### PR TITLE
CE02SHSP Reference Designator Fix

### DIFF
--- a/CE02SHSP/CE02SHSP_D00011_ingest.csv
+++ b/CE02SHSP/CE02SHSP_D00011_ingest.csv
@@ -1,9 +1,9 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_OPT.txt,CE02SHSP-SP001-02-DOSTAJ000,telemetered,Available,
+mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_OPT.txt,CE02SHSP-SP001-01-DOSTAJ000,telemetered,Available,
+mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_ADCP.txt,CE02SHSP-SP001-02-VELPTJ000,telemetered,Available,
 #mi.dataset.driver.optaa_dj.cspp.optaa_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_ACD_ACS.txt,CE02SHSP-SP001-04-OPTAAJ000,telemetered,Not Expected,Data too large to be telemetered
-mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_ADCP.txt,CE02SHSP-SP001-05-VELPTJ000,telemetered,Available,
-#mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_SND_SNA.txt,CE02SHSP-SP001-06-NUTNRJ000,telemetered,Not Expected,Data too large to be telemetered
-mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_OCR.txt,CE02SHSP-SP001-07-SPKIRJ000,telemetered,Available,
-mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_TRIP.txt,CE02SHSP-SP001-08-FLORTJ000,telemetered,Available,
-mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_CTD.txt,CE02SHSP-SP001-09-CTDPFJ000,telemetered,Available,
-mi.dataset.driver.parad_j.cspp.parad_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_PARS.txt,CE02SHSP-SP001-10-PARADJ000,telemetered,Available,
+#mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_SND_SNA.txt,CE02SHSP-SP001-05-NUTNRJ000,telemetered,Not Expected,Data too large to be telemetered
+mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_OCR.txt,CE02SHSP-SP001-06-SPKIRJ000,telemetered,Available,
+mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_TRIP.txt,CE02SHSP-SP001-07-FLORTJ000,telemetered,Available,
+mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_CTD.txt,CE02SHSP-SP001-08-CTDPFJ000,telemetered,Available,
+mi.dataset.driver.parad_j.cspp.parad_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00011/extract/ucspp_*_PPD_PARS.txt,CE02SHSP-SP001-09-PARADJ000,telemetered,Available,

--- a/CE02SHSP/CE02SHSP_D00016_ingest.csv
+++ b/CE02SHSP/CE02SHSP_D00016_ingest.csv
@@ -1,9 +1,9 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_OPT.txt,CE02SHSP-SP001-02-DOSTAJ000,telemetered,Available,
+mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_OPT.txt,CE02SHSP-SP001-01-DOSTAJ000,telemetered,Available,
+mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_ADCP.txt,CE02SHSP-SP001-02-VELPTJ000,telemetered,Available,
 #mi.dataset.driver.optaa_dj.cspp.optaa_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_ACD_ACS.txt,CE02SHSP-SP001-04-OPTAAJ000,telemetered,Not Expected,Data too large to be telemetered
-mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_ADCP.txt,CE02SHSP-SP001-05-VELPTJ000,telemetered,Available,
-#mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_SND_SNA.txt,CE02SHSP-SP001-06-NUTNRJ000,telemetered,Not Expected,Data too large to be telemetered
-mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_OCR.txt,CE02SHSP-SP001-07-SPKIRJ000,telemetered,Available,
-mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_TRIP.txt,CE02SHSP-SP001-08-FLORTJ000,telemetered,Available,
-mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_CTD.txt,CE02SHSP-SP001-09-CTDPFJ000,telemetered,Available,
-mi.dataset.driver.parad_j.cspp.parad_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_PARS.txt,CE02SHSP-SP001-10-PARADJ000,telemetered,Available,
+#mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_SND_SNA.txt,CE02SHSP-SP001-05-NUTNRJ000,telemetered,Not Expected,Data too large to be telemetered
+mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_OCR.txt,CE02SHSP-SP001-06-SPKIRJ000,telemetered,Available,
+mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_TRIP.txt,CE02SHSP-SP001-07-FLORTJ000,telemetered,Available,
+mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_CTD.txt,CE02SHSP-SP001-08-CTDPFJ000,telemetered,Available,
+mi.dataset.driver.parad_j.cspp.parad_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00016/extract/ucspp_*_PPD_PARS.txt,CE02SHSP-SP001-09-PARADJ000,telemetered,Available,

--- a/CE02SHSP/CE02SHSP_D00017_ingest.csv
+++ b/CE02SHSP/CE02SHSP_D00017_ingest.csv
@@ -1,9 +1,9 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_OPT.txt,CE02SHSP-SP001-02-DOSTAJ000,telemetered,Available,
+mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_OPT.txt,CE02SHSP-SP001-01-DOSTAJ000,telemetered,Available,
+mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_ADCP.txt,CE02SHSP-SP001-02-VELPTJ000,telemetered,Available,
 #mi.dataset.driver.optaa_dj.cspp.optaa_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_ACD_ACS.txt,CE02SHSP-SP001-04-OPTAAJ000,telemetered,Not Expected,Data too large to be telemetered
-mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_ADCP.txt,CE02SHSP-SP001-05-VELPTJ000,telemetered,Available,
-#mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_SND_SNA.txt,CE02SHSP-SP001-06-NUTNRJ000,telemetered,Not Expected,Data too large to be telemetered
-mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_OCR.txt,CE02SHSP-SP001-07-SPKIRJ000,telemetered,Available,
-mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_TRIP.txt,CE02SHSP-SP001-08-FLORTJ000,telemetered,Available,
-mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_CTD.txt,CE02SHSP-SP001-09-CTDPFJ000,telemetered,Available,
-mi.dataset.driver.parad_j.cspp.parad_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_PARS.txt,CE02SHSP-SP001-10-PARADJ000,telemetered,Available,
+#mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_SND_SNA.txt,CE02SHSP-SP001-05-NUTNRJ000,telemetered,Not Expected,Data too large to be telemetered
+mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_OCR.txt,CE02SHSP-SP001-06-SPKIRJ000,telemetered,Available,
+mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_TRIP.txt,CE02SHSP-SP001-07-FLORTJ000,telemetered,Available,
+mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_CTD.txt,CE02SHSP-SP001-08-CTDPFJ000,telemetered,Available,
+mi.dataset.driver.parad_j.cspp.parad_j_cspp_telemetered_driver,/omc_data/whoi/OMC/CE02SHSP/D00017/extract/ucspp_*_PPD_PARS.txt,CE02SHSP-SP001-09-PARADJ000,telemetered,Available,


### PR DESCRIPTION
For reasons that shall always remain opaque to me, the port assignments that comprise the reference designators for CE02SHSP are different from all other CSPPs. This corrects them in the telemetered ingest files.