### PR TITLE
Updating pco2a parser

### DIFF
--- a/CP01CNSM/CP01CNSM_D00011_ingest.csv
+++ b/CP01CNSM/CP01CNSM_D00011_ingest.csv
@@ -29,7 +29,7 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00011/cg_data/dcl11/metbk*/*metbk*.log,CP01CNSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00011/cg_data/dcl12/syslog*/*syslog*.log,CP01CNSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00011/cg_data/dcl12/hyd*/*hyd*.log,CP01CNSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP01CNSM/D00011/cg_data/dcl12/pco2a*/*pco2a*.log,CP01CNSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00011/cg_data/dcl12/pco2a*/*pco2a*.log,CP01CNSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00011/cg_data/dcl12/wavss*/*wavss*.log,CP01CNSM-SBD12-05-WAVSSA000,telemetered,Available,
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00011/cg_data/dcl12/metbk*/*metbk*.log,CP01CNSM-SBD12-06-METBKA000,telemetered,Available,
 mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00011/cg_data/dcl12/fdchp*/*fdchp*.log,CP01CNSM-SBD12-08-FDCHPA000,telemetered,Available,

--- a/CP01CNSM/CP01CNSM_D00012_ingest.csv
+++ b/CP01CNSM/CP01CNSM_D00012_ingest.csv
@@ -29,7 +29,7 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00012/cg_data/dcl11/metbk*/*metbk*.log,CP01CNSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00012/cg_data/dcl12/syslog*/*syslog*.log,CP01CNSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00012/cg_data/dcl12/hyd*/*hyd*.log,CP01CNSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP01CNSM/D00012/cg_data/dcl12/pco2a*/*pco2a*.log,CP01CNSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00012/cg_data/dcl12/pco2a*/*pco2a*.log,CP01CNSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00012/cg_data/dcl12/wavss*/*wavss*.log,CP01CNSM-SBD12-05-WAVSSA000,telemetered,Available,
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00012/cg_data/dcl12/metbk*/*metbk*.log,CP01CNSM-SBD12-06-METBKA000,telemetered,Available,
 mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP01CNSM/D00012/cg_data/dcl12/fdchp*/*fdchp*.log,CP01CNSM-SBD12-08-FDCHPA000,telemetered,Available,

--- a/CP01CNSM/CP01CNSM_R00011_ingest.csv
+++ b/CP01CNSM/CP01CNSM_R00011_ingest.csv
@@ -40,7 +40,7 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CP01CN
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CP01CNSM/R00011/cg_data/dcl11/metbk1/*.metbk1.log,CP01CNSM-SBD11-06-METBKA000,recovered_host,Expected,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CP01CNSM/R00011/cg_data/dcl12/syslog/*.syslog.log,CP01CNSM-SBD12-00-DCLENG000,recovered_host,Expected,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CP01CNSM/R00011/cg_data/dcl12/hyd2/*.hyd2.log,CP01CNSM-SBD12-03-HYDGN0000,recovered_host,Expected,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP01CNSM/R00011/cg_data/dcl12/pco2a/*pco2a.log,CP01CNSM-SBD12-04-PCO2AA000,recovered_host,Expected,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CP01CNSM/R00011/cg_data/dcl12/pco2a/*pco2a.log,CP01CNSM-SBD12-04-PCO2AA000,recovered_host,Expected,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CP01CNSM/R00011/cg_data/dcl12/wavss/*.wavss.log,CP01CNSM-SBD12-05-WAVSSA000,recovered_host,Expected,
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CP01CNSM/R00011/cg_data/dcl12/metbk2/*metbk2.log,CP01CNSM-SBD12-06-METBKA000,recovered_host,Expected,
 mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_recovered_driver,/omc_data/whoi/OMC/CP01CNSM/R00011/cg_data/dcl12/fdchp/*fdchp.log,CP01CNSM-SBD12-08-FDCHPA000,recovered_host,Expected,

--- a/CP03ISSM/CP03ISSM_D00010_ingest.csv
+++ b/CP03ISSM/CP03ISSM_D00010_ingest.csv
@@ -29,4 +29,4 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00010/cg_data/dcl11/metbk/*.metbk*.log,CP03ISSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00010/cg_data/dcl12/syslog/*.syslog.log,CP03ISSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00010/cg_data/dcl12/hyd2/*hyd2.log,CP03ISSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP03ISSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CP03ISSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CP03ISSM-SBD12-04-PCO2AA000,telemetered,Available,

--- a/CP03ISSM/CP03ISSM_D00011_ingest.csv
+++ b/CP03ISSM/CP03ISSM_D00011_ingest.csv
@@ -29,4 +29,4 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00011/cg_data/dcl11/metbk/*.metbk*.log,CP03ISSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00011/cg_data/dcl12/syslog/*.syslog.log,CP03ISSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00011/cg_data/dcl12/hyd2/*hyd2.log,CP03ISSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP03ISSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CP03ISSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CP03ISSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CP03ISSM-SBD12-04-PCO2AA000,telemetered,Available,

--- a/CP03ISSM/CP03ISSM_R00010_ingest.csv
+++ b/CP03ISSM/CP03ISSM_R00010_ingest.csv
@@ -40,4 +40,4 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CP03IS
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CP03ISSM/R00010/cg_data/dcl11/metbk/*.metbk.log,CP03ISSM-SBD11-06-METBKA000,recovered_host,Expected,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CP03ISSM/R00010/cg_data/dcl12/syslog/*.syslog.log,CP03ISSM-SBD12-00-DCLENG000,recovered_host,Expected,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CP03ISSM/R00010/cg_data/dcl12/hyd2/*.hyd2.log,CP03ISSM-SBD12-03-HYDGN0000,recovered_host,Expected,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP03ISSM/R00010/cg_data/dcl12/pco2a/*pco2a.log,CP03ISSM-SBD12-04-PCO2AA000,recovered_host,Expected,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CP03ISSM/R00010/cg_data/dcl12/pco2a/*pco2a.log,CP03ISSM-SBD12-04-PCO2AA000,recovered_host,Expected,

--- a/CP04OSSM/CP04OSSM_D00010_ingest.csv
+++ b/CP04OSSM/CP04OSSM_D00010_ingest.csv
@@ -29,4 +29,4 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00010/cg_data/dcl11/metbk/*.metbk.log,CP04OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00010/cg_data/dcl12/syslog/*.syslog.log,CP04OSSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00010/cg_data/dcl12/hyd*/*hyd*.log,CP04OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP04OSSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CP04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CP04OSSM-SBD12-04-PCO2AA000,telemetered,Available,

--- a/CP04OSSM/CP04OSSM_D00011_ingest.csv
+++ b/CP04OSSM/CP04OSSM_D00011_ingest.csv
@@ -29,4 +29,4 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00011/cg_data/dcl11/metbk/*.metbk.log,CP04OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00011/cg_data/dcl12/syslog/*.syslog.log,CP04OSSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00011/cg_data/dcl12/hyd*/*hyd*.log,CP04OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP04OSSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CP04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CP04OSSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CP04OSSM-SBD12-04-PCO2AA000,telemetered,Available,

--- a/CP04OSSM/CP04OSSM_R00010_ingest.csv
+++ b/CP04OSSM/CP04OSSM_R00010_ingest.csv
@@ -40,4 +40,4 @@ mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CP04OS
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CP04OSSM/R00010/cg_data/dcl11/metbk/*.metbk.log,CP04OSSM-SBD11-06-METBKA000,recovered_host,Expected,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CP04OSSM/R00010/cg_data/dcl12/syslog/*.syslog.log,CP04OSSM-SBD12-00-DCLENG000,recovered_host,Expected,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CP04OSSM/R00010/cg_data/dcl12/hyd2/*.hyd2.log,CP04OSSM-SBD12-03-HYDGN0000,recovered_host,Expected,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CP04OSSM/R00010/cg_data/dcl12/pco2a/*.pco2a.log,CP04OSSM-SBD12-04-PCO2AA000,recovered_host,Expected,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CP04OSSM/R00010/cg_data/dcl12/pco2a/*.pco2a.log,CP04OSSM-SBD12-04-PCO2AA000,recovered_host,Expected,


### PR DESCRIPTION
The pco2a's with the firmware update were first deployed in Spring 2019 and required a parser change. Two parsers were created for recovered and telemetered data.

The new driver's should be:
mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver

and

mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver

I updated the following impacted ingestion csvs:
CP01CNSM D00011, D00012 and R00011
CP03ISSM D00010, D00011, and R00010
CP04OSSM D00010, D00011, and R00010