### PR TITLE
Ingest sheets for recent R/V Pacific Storm Cruise

### DIFF
--- a/CE01ISSP/CE01ISSP_R00015_ingest.csv
+++ b/CE01ISSP/CE01ISSP_R00015_ingest.csv
@@ -1,0 +1,13 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.dbg_pdbg.cspp.dbg_pdbg_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*PDBG.txt,CE01ISSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_hmr.cspp.wc_hmr_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*WC_HMR.txt,CE01ISSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_sbe.cspp.wc_sbe_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*WC_SBE.txt,CE01ISSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_wm.cspp.wc_wm_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*WC_WM.txt,CE01ISSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*OPT.txt,CE01ISSP-SP001-02-DOSTAJ000,recovered_cspp,Available,
+mi.dataset.driver.optaa_dj.cspp.optaa_dj_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*ACS.txt,CE01ISSP-SP001-04-OPTAAJ000,recovered_cspp,Available,
+mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*ADCP.txt,CE01ISSP-SP001-05-VELPTJ000,recovered_cspp,Available,
+mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*SNA.txt,CE01ISSP-SP001-06-NUTNRJ000,recovered_cspp,Available,
+mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*OCR.txt,CE01ISSP-SP001-07-SPKIRJ000,recovered_cspp,Available,
+mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*TRIP.txt,CE01ISSP-SP001-08-FLORTJ000,recovered_cspp,Available,
+mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*CTD.txt,CE01ISSP-SP001-09-CTDPFJ000,recovered_cspp,Available,
+mi.dataset.driver.parad_j.cspp.parad_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE01ISSP/R00015/extract/*PARS.txt,CE01ISSP-SP001-10-PARADJ000,recovered_cspp,Available,

--- a/CE05MOAS-GL311/CE05MOAS-GL311_R00010_ingest.csv
+++ b/CE05MOAS-GL311/CE05MOAS-GL311_R00010_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/R00010/merged/ce_*.full.mrg,CE05MOAS-GL311-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/R00010/merged/ce_*.full.mrg,CE05MOAS-GL311-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/R00010/merged/ce_*.full.mrg,CE05MOAS-GL311-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/R00010/dvl/*.pd0,CE05MOAS-GL311-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/R00010/merged/ce_*.full.mrg,CE05MOAS-GL311-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/R00010/merged/ce_*.full.mrg,CE05MOAS-GL311-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL312/CE05MOAS-GL312_R00010_ingest.csv
+++ b/CE05MOAS-GL312/CE05MOAS-GL312_R00010_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00010/merged/ce_*.full.mrg,CE05MOAS-GL312-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00010/merged/ce_*.full.mrg,CE05MOAS-GL312-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00010/merged/ce_*.full.mrg,CE05MOAS-GL312-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00010/dvl/*.pd0,CE05MOAS-GL312-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00010/merged/ce_*.full.mrg,CE05MOAS-GL312-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00010/merged/ce_*.full.mrg,CE05MOAS-GL312-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL386/CE05MOAS-GL386_D00012_ingest.csv
+++ b/CE05MOAS-GL386/CE05MOAS-GL386_D00012_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL386-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL386-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL386-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL386-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL386-05-CTDGVM000,telemetered,Available,

--- a/CE06ISSP/CE06ISSP_R00012_ingest.csv
+++ b/CE06ISSP/CE06ISSP_R00012_ingest.csv
@@ -1,0 +1,13 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.dbg_pdbg.cspp.dbg_pdbg_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*PDBG.txt,CE06ISSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_hmr.cspp.wc_hmr_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*WC_HMR.txt,CE06ISSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_sbe.cspp.wc_sbe_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*WC_SBE.txt,CE06ISSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_wm.cspp.wc_wm_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*WC_WM.txt,CE06ISSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*OPT.txt,CE06ISSP-SP001-02-DOSTAJ000,recovered_cspp,Available,
+mi.dataset.driver.optaa_dj.cspp.optaa_dj_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*ACS.txt,CE06ISSP-SP001-04-OPTAAJ000,recovered_cspp,Available,
+mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*ADCP.txt,CE06ISSP-SP001-05-VELPTJ000,recovered_cspp,Available,
+mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*SNA.txt,CE06ISSP-SP001-06-NUTNRJ000,recovered_cspp,Available,
+mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*OCR.txt,CE06ISSP-SP001-07-SPKIRJ000,recovered_cspp,Available,
+mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*TRIP.txt,CE06ISSP-SP001-08-FLORTJ000,recovered_cspp,Available,
+mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*CTD.txt,CE06ISSP-SP001-09-CTDPFJ000,recovered_cspp,Available,
+mi.dataset.driver.parad_j.cspp.parad_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE06ISSP/R00012/extract/*PARS.txt,CE06ISSP-SP001-10-PARADJ000,recovered_cspp,Available,

--- a/CE07SHSP/CE07SHSP_R00009_ingest.csv
+++ b/CE07SHSP/CE07SHSP_R00009_ingest.csv
@@ -1,0 +1,13 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.dbg_pdbg.cspp.dbg_pdbg_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*PDBG.txt,CE07SHSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_hmr.cspp.wc_hmr_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*WC_HMR.txt,CE07SHSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_sbe.cspp.wc_sbe_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*WC_SBE.txt,CE07SHSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.wc_wm.cspp.wc_wm_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*WC_WM.txt,CE07SHSP-SP001-00-SPPENG000,recovered_cspp,Available,
+mi.dataset.driver.dosta_abcdjm.cspp.dosta_abcdjm_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*OPT.txt,CE07SHSP-SP001-01-DOSTAJ000,recovered_cspp,Available,
+mi.dataset.driver.velpt_j.cspp.velpt_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*ADCP.txt,CE07SHSP-SP001-02-VELPTJ000,recovered_cspp,Available,
+mi.dataset.driver.optaa_dj.cspp.optaa_dj_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*ACS.txt,CE07SHSP-SP001-04-OPTAAJ000,recovered_cspp,Available,
+mi.dataset.driver.nutnr_j.cspp.nutnr_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*SNA.txt,CE07SHSP-SP001-05-NUTNRJ000,recovered_cspp,Available,
+mi.dataset.driver.spkir_abj.cspp.spkir_abj_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*OCR.txt,CE07SHSP-SP001-06-SPKIRJ000,recovered_cspp,Available,
+mi.dataset.driver.flort_dj.cspp.flort_dj_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*TRIP.txt,CE07SHSP-SP001-07-FLORTJ000,recovered_cspp,Available,
+mi.dataset.driver.ctdpf_j.cspp.ctdpf_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*CTD.txt,CE07SHSP-SP001-08-CTDPFJ000,recovered_cspp,Available,
+mi.dataset.driver.parad_j.cspp.parad_j_cspp_recovered_driver,/omc_data/whoi/OMC/CE07SHSP/R00009/extract/*PARS.txt,CE07SHSP-SP001-09-PARADJ000,recovered_cspp,Available,


### PR DESCRIPTION
Creates recovered ingest sheets for CSPPs and gliders and a telemetered ingest sheet for glider 386.