### PR TITLE
Recovered ingestion csvs for Pioneer 14a, 14b, and 14c gliders

### DIFF
--- a/CP05MOAS-GL340/CP05MOAS-GL340_R00011_ingest.csv
+++ b/CP05MOAS-GL340/CP05MOAS-GL340_R00011_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/R00011/merged/cp_*.mrg,CP05MOAS-GL340-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/R00011/dvl/*.PD0,CP05MOAS-GL340-01-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/R00011/merged/cp_*.mrg,CP05MOAS-GL340-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/R00011/merged/cp_*.mrg,CP05MOAS-GL340-03-CTDGVM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/R00011/merged/cp_*.mrg,CP05MOAS-GL340-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL340/R00011/merged/cp_*.mrg,CP05MOAS-GL340-05-PARADM000,recovered_host,Available,

--- a/CP05MOAS-GL376/CP05MOAS-GL376_R00012_ingest.csv
+++ b/CP05MOAS-GL376/CP05MOAS-GL376_R00012_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL376/R00012/merged/cp_*.mrg,CP05MOAS-GL376-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL376/R00012/dvl/*.PD0,CP05MOAS-GL376-01-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL376/R00012/merged/cp_*.mrg,CP05MOAS-GL376-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL376/R00012/merged/cp_*.mrg,CP05MOAS-GL376-03-CTDGVM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL376/R00012/merged/cp_*.mrg,CP05MOAS-GL376-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL376/R00012/merged/cp_*.mrg,CP05MOAS-GL376-05-PARADM000,recovered_host,Available,

--- a/CP05MOAS-GL379/CP05MOAS-GL379_R00010_ingest.csv
+++ b/CP05MOAS-GL379/CP05MOAS-GL379_R00010_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/R00010/merged/cp_*.mrg,CP05MOAS-GL379-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/R00010/dvl/*.PD0,CP05MOAS-GL379-01-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/R00010/merged/cp_*.mrg,CP05MOAS-GL379-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/R00010/merged/cp_*.mrg,CP05MOAS-GL379-03-CTDGVM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/R00010/merged/cp_*.mrg,CP05MOAS-GL379-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-GL379/R00010/merged/cp_*.mrg,CP05MOAS-GL379-05-PARADM000,recovered_host,Available,

--- a/CP05MOAS-PG583/CP05MOAS-PG583_R00002_ingest.csv
+++ b/CP05MOAS-PG583/CP05MOAS-PG583_R00002_ingest.csv
@@ -1,0 +1,8 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00002/merged/cp_*.mrg,CP05MOAS-PG583-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00002/merged/cp_*.mrg,CP05MOAS-PG583-01-CTDGVM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00002/merged/cp_*.mrg,CP05MOAS-PG583-02-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00002/merged/cp_*.mrg,CP05MOAS-PG583-03-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_o.flort_o_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00002/merged/cp_*.mrg,CP05MOAS-PG583-04-FLORTO000,recovered_host,Available,
+mi.dataset.driver.nutnr_m.glider.nutnr_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00002/merged/cp_*.mrg,CP05MOAS-PG583-05-NUTNRM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00002/merged/cp_*.mrg,CP05MOAS-PG583-06-PARADM000,recovered_host,Available,

--- a/CP05MOAS-PG583/CP05MOAS-PG583_R00003_ingest.csv
+++ b/CP05MOAS-PG583/CP05MOAS-PG583_R00003_ingest.csv
@@ -1,0 +1,8 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00003/merged/cp_*.mrg,CP05MOAS-PG583-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00003/merged/cp_*.mrg,CP05MOAS-PG583-01-CTDGVM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00003/merged/cp_*.mrg,CP05MOAS-PG583-02-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00003/merged/cp_*.mrg,CP05MOAS-PG583-03-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_o.flort_o_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00003/merged/cp_*.mrg,CP05MOAS-PG583-04-FLORTO000,recovered_host,Available,
+mi.dataset.driver.nutnr_m.glider.nutnr_m_glider_telemetered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00003/merged/cp_*.mrg,CP05MOAS-PG583-05-NUTNRM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CP05MOAS-PG583/R00003/merged/cp_*.mrg,CP05MOAS-PG583-06-PARADM000,recovered_host,Available,


### PR DESCRIPTION
Created recovered ingestion csvs for the following Pioneer 14a glider:
CP05MOAS-PG583 - R00002

And following Pioneer 14b gliders:
CP05MOAS-PG583 - R00003
CP05MOAS-GL376 - R00012
CP05MOAS-GL379 - R00010

And following Pioneer 14c glider:
CP05MOAS-GL340 - R00011