### PR TITLE
Updates telemetered PCO2A drivers

### DIFF
--- a/CE02SHSM/CE02SHSM_D00009_ingest.csv
+++ b/CE02SHSM/CE02SHSM_D00009_ingest.csv
@@ -19,6 +19,6 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00009/cg_data/dcl11/metbk/*.metbk.log,CE02SHSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00009/cg_data/dcl12/syslog/*.syslog.log,CE02SHSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00009/cg_data/dcl12/hyd2/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE02SHSM/D00009/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00009/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00009/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,telemetered,Available,
 mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00009/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,telemetered,Available,

--- a/CE02SHSM/CE02SHSM_D00010_ingest.csv
+++ b/CE02SHSM/CE02SHSM_D00010_ingest.csv
@@ -19,6 +19,6 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00010/cg_data/dcl11/metbk/*.metbk.log,CE02SHSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00010/cg_data/dcl12/syslog/*.syslog.log,CE02SHSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00010/cg_data/dcl12/hyd2/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE02SHSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00010/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,telemetered,Available,
 mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00010/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,telemetered,Available,

--- a/CE02SHSM/CE02SHSM_D00011_ingest.csv
+++ b/CE02SHSM/CE02SHSM_D00011_ingest.csv
@@ -19,6 +19,6 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00011/cg_data/dcl11/metbk/*.metbk.log,CE02SHSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00011/cg_data/dcl12/syslog/*.syslog.log,CE02SHSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00011/cg_data/dcl12/hyd2/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE02SHSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00011/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,telemetered,Available,
 mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00011/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,telemetered,Available,

--- a/CE02SHSM/CE02SHSM_D00012_ingest.csv
+++ b/CE02SHSM/CE02SHSM_D00012_ingest.csv
@@ -19,6 +19,6 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00012/cg_data/dcl11/metbk/*.metbk.log,CE02SHSM-SBD11-06-METBKA000,telemetered,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00012/cg_data/dcl12/syslog/*.syslog.log,CE02SHSM-SBD12-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00012/cg_data/dcl12/hyd2/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE02SHSM/D00012/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00012/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00012/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,telemetered,Available,
 mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE02SHSM/D00012/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,telemetered,Available,

--- a/CE04OSSM/CE04OSSM_D00008_ingest.csv
+++ b/CE04OSSM/CE04OSSM_D00008_ingest.csv
@@ -19,5 +19,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00008/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00008/cg_data/dcl12/syslog/*.syslog.log,CE04OSSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00008/cg_data/dcl12/hyd2/*.hyd*.log,CE04OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE04OSSM/D00008/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00008/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00008/cg_data/dcl12/wavss/*.wavss.log,CE04OSSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE04OSSM/CE04OSSM_D00009_ingest.csv
+++ b/CE04OSSM/CE04OSSM_D00009_ingest.csv
@@ -19,5 +19,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00009/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00009/cg_data/dcl12/syslog/*.syslog.log,CE04OSSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00009/cg_data/dcl12/hyd2/*.hyd*.log,CE04OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE04OSSM/D00009/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00009/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00009/cg_data/dcl12/wavss/*.wavss.log,CE04OSSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE04OSSM/CE04OSSM_D00010_ingest.csv
+++ b/CE04OSSM/CE04OSSM_D00010_ingest.csv
@@ -19,5 +19,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00010/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00010/cg_data/dcl12/syslog/*.syslog.log,CE04OSSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00010/cg_data/dcl12/hyd2/*.hyd*.log,CE04OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE04OSSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00010/cg_data/dcl12/wavss/*.wavss.log,CE04OSSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE04OSSM/CE04OSSM_D00011_ingest.csv
+++ b/CE04OSSM/CE04OSSM_D00011_ingest.csv
@@ -19,5 +19,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00011/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA000,telemetered,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00011/cg_data/dcl12/syslog/*.syslog.log,CE04OSSM-SBD12-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00011/cg_data/dcl12/hyd2/*.hyd*.log,CE04OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE04OSSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE04OSSM/D00011/cg_data/dcl12/wavss/*.wavss.log,CE04OSSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE07SHSM/CE07SHSM_D00009_ingest.csv
+++ b/CE07SHSM/CE07SHSM_D00009_ingest.csv
@@ -32,5 +32,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00009/cg_data/dcl11/metbk/*.metbk.log,CE07SHSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00009/cg_data/dcl12/syslog/*.syslog.log,CE07SHSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00009/cg_data/dcl12/hyd2/*.hyd*.log,CE07SHSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE07SHSM/D00009/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00009/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00009/cg_data/dcl12/wavss/*.wavss.log,CE07SHSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE07SHSM/CE07SHSM_D00010_ingest.csv
+++ b/CE07SHSM/CE07SHSM_D00010_ingest.csv
@@ -32,5 +32,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00010/cg_data/dcl11/metbk/*.metbk.log,CE07SHSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00010/cg_data/dcl12/syslog/*.syslog.log,CE07SHSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00010/cg_data/dcl12/hyd2/*.hyd*.log,CE07SHSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE07SHSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00010/cg_data/dcl12/wavss/*.wavss.log,CE07SHSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE07SHSM/CE07SHSM_D00011_ingest.csv
+++ b/CE07SHSM/CE07SHSM_D00011_ingest.csv
@@ -32,5 +32,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00011/cg_data/dcl11/metbk/*.metbk.log,CE07SHSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00011/cg_data/dcl12/syslog/*.syslog.log,CE07SHSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00011/cg_data/dcl12/hyd2/*.hyd*.log,CE07SHSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE07SHSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00011/cg_data/dcl12/wavss/*.wavss.log,CE07SHSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE07SHSM/CE07SHSM_D00012_ingest.csv
+++ b/CE07SHSM/CE07SHSM_D00012_ingest.csv
@@ -32,5 +32,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00012/cg_data/dcl11/metbk/*.metbk.log,CE07SHSM-SBD11-06-METBKA000,telemetered,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00012/cg_data/dcl12/syslog/*.syslog.log,CE07SHSM-SBD12-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00012/cg_data/dcl12/hyd2/*.hyd*.log,CE07SHSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE07SHSM/D00012/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00012/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/D00012/cg_data/dcl12/wavss/*.wavss.log,CE07SHSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE09OSSM/CE09OSSM_D00009_ingest.csv
+++ b/CE09OSSM/CE09OSSM_D00009_ingest.csv
@@ -32,5 +32,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00009/cg_data/dcl11/metbk/*.metbk.log,CE09OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00009/cg_data/dcl12/syslog/*.syslog.log,CE09OSSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00009/cg_data/dcl12/hyd*/*.hyd*.log,CE09OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE09OSSM/D00009/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00009/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00009/cg_data/dcl12/wavss/*.wavss.log,CE09OSSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE09OSSM/CE09OSSM_D00010_ingest.csv
+++ b/CE09OSSM/CE09OSSM_D00010_ingest.csv
@@ -32,5 +32,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00010/cg_data/dcl11/metbk/*.metbk.log,CE09OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00010/cg_data/dcl12/syslog/*.syslog.log,CE09OSSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00010/cg_data/dcl12/hyd*/*.hyd*.log,CE09OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE09OSSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00010/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00010/cg_data/dcl12/wavss/*.wavss.log,CE09OSSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE09OSSM/CE09OSSM_D00011_ingest.csv
+++ b/CE09OSSM/CE09OSSM_D00011_ingest.csv
@@ -32,5 +32,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00011/cg_data/dcl11/metbk/*.metbk.log,CE09OSSM-SBD11-06-METBKA000,telemetered,Available,
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00011/cg_data/dcl12/syslog/*.syslog.log,CE09OSSM-SBD12-00-DCLENG000,telemetered,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00011/cg_data/dcl12/hyd*/*.hyd*.log,CE09OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE09OSSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00011/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00011/cg_data/dcl12/wavss/*.wavss.log,CE09OSSM-SBD12-05-WAVSSA000,telemetered,Available,

--- a/CE09OSSM/CE09OSSM_D00012_ingest.csv
+++ b/CE09OSSM/CE09OSSM_D00012_ingest.csv
@@ -32,5 +32,5 @@ mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00012/cg_data/dcl11/metbk/*.metbk.log,CE09OSSM-SBD11-06-METBKA000,telemetered,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00012/cg_data/dcl12/syslog/*.syslog.log,CE09OSSM-SBD12-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00012/cg_data/dcl12/hyd*/*.hyd*.log,CE09OSSM-SBD12-03-HYDGN0000,telemetered,Available,
-mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_driver,/omc_data/whoi/OMC/CE09OSSM/D00012/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,telemetered,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00012/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,telemetered,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00012/cg_data/dcl12/wavss/*.wavss.log,CE09OSSM-SBD12-05-WAVSSA000,telemetered,Available,


### PR DESCRIPTION
Updates the driver for the telemetered PCO2A data streams to use the correctly specified telemetered driver (applies only to the newer datasets collected after the instrument firmware was updated).