### PR TITLE
Updates for instrument failures and one not deployed

### DIFF
--- a/CE01ISSM/CE01ISSM_R00013_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00013_ingest.csv
@@ -14,7 +14,7 @@ mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl36/pco2w*/*pco2w*.log,CE01ISSM-MFD35-05-PCO2WB000,recovered_host,Available,
 mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-MFD35-05-PCO2WB000,recovered_inst,Available,
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl36/phsen*/*phsen*.log,CE01ISSM-MFD35-06-PHSEND000,recovered_host,Available,
-mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE01ISSM-MFD35-06-PHSEND000,recovered_inst,Available,
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE01ISSM-MFD35-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl37/syslog*/*syslog*.log,CE01ISSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl37/optaa*/*optaa*.log,CE01ISSM-MFD37-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE01ISSM-MFD37-03-CTDBPC000,recovered_host,Available,
@@ -35,7 +35,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl16/velpt*/*velpt*.log,CE01ISSM-RID16-04-VELPTA000,recovered_host,Available,
 mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl16/VELPT*/*velpt*.aqd,CE01ISSM-RID16-04-VELPTA000,recovered_inst,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl16/pco2w*/*pco2w*.log,CE01ISSM-RID16-05-PCO2WB000,recovered_host,Available,
-mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-RID16-05-PCO2WB000,recovered_inst,Available,
+# mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-RID16-05-PCO2WB000,recovered_inst,Not Expected,Instrument battery failure
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl16/phsen*/*phsen*.log,CE01ISSM-RID16-06-PHSEND000,recovered_host,Available,
 mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl16/PHSEN*/*phsen*recovered*.txt,CE01ISSM-RID16-06-PHSEND000,recovered_inst,Available,
 mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl16/nutnr*/*nutnr*.log,CE01ISSM-RID16-07-NUTNRB000,recovered_host,Available,

--- a/CE02SHSM/CE02SHSM_R00011_ingest.csv
+++ b/CE02SHSM/CE02SHSM_R00011_ingest.csv
@@ -27,5 +27,5 @@ mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00011/cg_data/dcl12/hyd*/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,recovered_host,Available,
 mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00011/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,recovered_host,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00011/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,recovered_host,Available,
-mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00011/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,recovered_host,Available,
-mi.dataset.driver.fdchp_a.fdchp_a_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00011/instrmts/dcl12/FDCHP*/*fdchp*/*/fdchp*.dat,CE02SHSM-SBD12-08-FDCHPA000,recovered_inst,Available,
+# mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00011/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,recovered_host,Not Deployed,
+# mi.dataset.driver.fdchp_a.fdchp_a_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00011/instrmts/dcl12/FDCHP*/*fdchp*/*/fdchp*.dat,CE02SHSM-SBD12-08-FDCHPA000,recovered_inst,Not Deployed,

--- a/CE07SHSM/CE07SHSM_R00011_ingest.csv
+++ b/CE07SHSM/CE07SHSM_R00011_ingest.csv
@@ -8,9 +8,9 @@ mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE07SH
 mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl36/adcpt2/*.adcpt*.log,CE07SHSM-MFD35-04-ADCPTC000,recovered_host,Available,
 mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl36/ADCPT*/*.000,CE07SHSM-MFD35-04-ADCPTC000,recovered_inst,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl36/pco2w/*.pco2w.log,CE07SHSM-MFD35-05-PCO2WB000,recovered_host,Available,
-mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE07SHSM-MFD35-05-PCO2WB000,recovered_inst,Available,
+# mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE07SHSM-MFD35-05-PCO2WB000,recovered_inst,Not Expected,Instrument battery failure
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl36/phsen2/*.phsen*.log,CE07SHSM-MFD35-06-PHSEND000,recovered_host,Available,
-mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE07SHSM-MFD35-06-PHSEND000,recovered_inst,Available,
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE07SHSM-MFD35-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl37/syslog/*.syslog.log,CE07SHSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl37/optaa2/*.optaa*.log,CE07SHSM-MFD37-01-OPTAAD000,recovered_host,Not Deployed,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl37/ctdbp2/*.ctdbp*.log,CE07SHSM-MFD37-03-CTDBPC000,recovered_host,Available,
@@ -28,7 +28,7 @@ mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl26/velpt2/*.velpt*.log,CE07SHSM-RID26-04-VELPTA000,recovered_host,Available,
 mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl26/VELPT*/*velpt*.aqd,CE07SHSM-RID26-04-VELPTA000,recovered_inst,Available,
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl26/phsen*/*.phsen*.log,CE07SHSM-RID26-06-PHSEND000,recovered_host,Available,
-mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE07SHSM-RID26-06-PHSEND000,recovered_inst,Available,
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE07SHSM-RID26-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
 mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl26/nutnr/*.nutnr.log,CE07SHSM-RID26-07-NUTNRB000,recovered_host,Available,
 mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/instrmts/dcl26/NUTNR*/*nutnr*/DAT/D*.CSV,CE07SHSM-RID26-07-NUTNRB000,recovered_inst,Available,
 mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00011/cg_data/dcl26/spkir/*.spkir.log,CE07SHSM-RID26-08-SPKIRB000,recovered_host,Available,


### PR DESCRIPTION
Final updates to the Endurance 12 recovered instrument and data logger ingest sheets to account for damaged/failed instruments.