### PR TITLE
adds CE glider ops.  Also changes glider 871 to the new G3 ref des style

### DIFF
--- a/CE05MOAS-G0871/CE05MOAS-G0871_D00001_ingest.csv
+++ b/CE05MOAS-G0871/CE05MOAS-G0871_D00001_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-G0871/CE05MOAS-G0871_D00002_ingest.csv
+++ b/CE05MOAS-G0871/CE05MOAS-G0871_D00002_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00002/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00002/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00002/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00002/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/D00002/merged-from-glider/ce_*.mrg,CE05MOAS-G0871-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-G0871/CE05MOAS-G0871_R00001_ingest.csv
+++ b/CE05MOAS-G0871/CE05MOAS-G0871_R00001_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/R00001/merged/ce_*.full.mrg,CE05MOAS-G0871-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/R00001/merged/ce_*.full.mrg,CE05MOAS-G0871-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/R00001/merged/ce_*.full.mrg,CE05MOAS-G0871-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/R00001/dvl/*.pd0,CE05MOAS-G0871-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/R00001/merged/ce_*.full.mrg,CE05MOAS-G0871-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0871/R00001/merged/ce_*.full.mrg,CE05MOAS-G0871-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL311/CE05MOAS-GL311_D00012_ingest.csv
+++ b/CE05MOAS-GL311/CE05MOAS-GL311_D00012_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL311/D00012/merged-from-glider/ce_*.mrg,CE05MOAS-GL311-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL326/CE05MOAS-GL326_R00009_ingest.csv
+++ b/CE05MOAS-GL326/CE05MOAS-GL326_R00009_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL326/R00009/merged/ce_*.full.mrg,CE05MOAS-GL326-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL326/R00009/merged/ce_*.full.mrg,CE05MOAS-GL326-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL326/R00009/merged/ce_*.full.mrg,CE05MOAS-GL326-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL326/R00009/dvl/*.pd0,CE05MOAS-GL326-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL326/R00009/merged/ce_*.full.mrg,CE05MOAS-GL326-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL326/R00009/merged/ce_*.full.mrg,CE05MOAS-GL326-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL383/CE05MOAS-GL383_D00011_ingest.csv
+++ b/CE05MOAS-GL383/CE05MOAS-GL383_D00011_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL383/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL383-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL383/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL383-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL383/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL383-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL383/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL383-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL383/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL383-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL386/CE05MOAS-GL386_R00013_ingest.csv
+++ b/CE05MOAS-GL386/CE05MOAS-GL386_R00013_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/R00013/merged/ce_*.full.mrg,CE05MOAS-GL386-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/R00013/merged/ce_*.full.mrg,CE05MOAS-GL386-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/R00013/merged/ce_*.full.mrg,CE05MOAS-GL386-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/R00013/dvl/*.pd0,CE05MOAS-GL386-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/R00013/merged/ce_*.full.mrg,CE05MOAS-GL386-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL386/R00013/merged/ce_*.full.mrg,CE05MOAS-GL386-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL871/CE05MOAS-GL871_D00001_ingest.csv
+++ b/CE05MOAS-GL871/CE05MOAS-GL871_D00001_ingest.csv
@@ -1,6 +1,0 @@
-parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-GL871-00-ENG000000,telemetered,Available,
-mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-GL871-01-PARADM000,telemetered,Available,
-mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-GL871-02-FLORTM000,telemetered,Available,
-mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-GL871-04-DOSTAM000,telemetered,Available,
-mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/D00001/merged-from-glider/ce_*.mrg,CE05MOAS-GL871-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL871/CE05MOAS-GL871_R00001_ingest.csv
+++ b/CE05MOAS-GL871/CE05MOAS-GL871_R00001_ingest.csv
@@ -1,7 +1,0 @@
-parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/R00001/merged/ce_*.full.mrg,CE05MOAS-GL871-00-ENG000000,recovered_host,Available,
-mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/R00001/merged/ce_*.full.mrg,CE05MOAS-GL871-01-PARADM000,recovered_host,Available,
-mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/R00001/merged/ce_*.full.mrg,CE05MOAS-GL871-02-FLORTM000,recovered_host,Available,
-mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/R00001/dvl/*.pd0,CE05MOAS-GL871-03-ADCPAM000,recovered_host,Available,
-mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/R00001/merged/ce_*.full.mrg,CE05MOAS-GL871-04-DOSTAM000,recovered_host,Available,
-mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL871/R00001/merged/ce_*.full.mrg,CE05MOAS-GL871-05-CTDGVM000,recovered_host,Available,


### PR DESCRIPTION
@cwingard and @cdobs Can you guys have a quick review of these ingestion sheets?  I updated 871 to the new Reference Designator style for G3s (and changed it for the already existing deployment of 871-00001) and wanted to make sure everything is correct.