### PR TITLE
Updates CE09OSSM for failed MFN power

### DIFF
--- a/CE09OSSM/CE09OSSM_D00013_ingest.csv
+++ b/CE09OSSM/CE09OSSM_D00013_ingest.csv
@@ -1,16 +1,16 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/cpm3/syslog/cpm_status.txt,CE09OSSM-MFC31-00-CPMENG000,telemetered,Pending,Incorrectly specified dataset and parser
-# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/syslog/*.syslog.log,CE09OSSM-MFD35-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset
-# mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/vel3d*/*.vel3d.log,CE09OSSM-MFD35-01-VEL3DD000,telemetered,Pending,Error in sensor clock blocking ingests
-mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/presf/*.presf.log,CE09OSSM-MFD35-02-PRESFC000,telemetered,Available,
-mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/adcps/*.adcps.log,CE09OSSM-MFD35-04-ADCPSJ000,telemetered,Available,
-mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/pco2w/*.pco2w.log,CE09OSSM-MFD35-05-PCO2WB000,telemetered,Available,
-mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/phsen*/*.phsen*.log,CE09OSSM-MFD35-06-PHSEND000,telemetered,Available,
-# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/syslog/*.syslog.log,CE09OSSM-MFD37-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset
-mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/optaa*/*.optaa*.log,CE09OSSM-MFD37-01-OPTAAC000,telemetered,Available,
-mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE09OSSM-MFD37-03-CTDBPE000,telemetered,Available,
-mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE09OSSM-MFD37-03-DOSTAD000,telemetered,Available,
-mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/zplsc/*.zplsc.log,CE09OSSM-MFD37-07-ZPLSCC000,telemetered,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/cpm3/syslog/cpm_status.txt,CE09OSSM-MFC31-00-CPMENG000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/syslog/*.syslog.log,CE09OSSM-MFD35-00-DCLENG000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/vel3d*/*.vel3d.log,CE09OSSM-MFD35-01-VEL3DD000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/presf/*.presf.log,CE09OSSM-MFD35-02-PRESFC000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/adcps/*.adcps.log,CE09OSSM-MFD35-04-ADCPSJ000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/pco2w/*.pco2w.log,CE09OSSM-MFD35-05-PCO2WB000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl36/phsen*/*.phsen*.log,CE09OSSM-MFD35-06-PHSEND000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/syslog/*.syslog.log,CE09OSSM-MFD37-00-DCLENG000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/optaa*/*.optaa*.log,CE09OSSM-MFD37-01-OPTAAC000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE09OSSM-MFD37-03-CTDBPE000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE09OSSM-MFD37-03-DOSTAD000,telemetered,Not Available,Power failed to the MFN
+# mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl37/zplsc/*.zplsc.log,CE09OSSM-MFD37-07-ZPLSCC000,telemetered,Not Available,Power failed to the MFN
 # ,/omc_data/whoi/OMC/CE09OSSM/D00013/,CE09OSSM-MFD37-06-CAMDSA000,telemetered,Not Deployed,No parser exists for this data set
 # mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/cpm2/syslog/cpm_status.txt,CE09OSSM-RIC21-00-CPMENG000,telemetered,Pending,Incorrectly specified dataset and parser
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00013/cg_data/dcl26/syslog/*.syslog.log,CE09OSSM-RID26-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset


### PR DESCRIPTION
Updates the CE09OSSM-D00013 ingest sheets to account for the failed MFN power.