### PR TITLE
Recovered Data Ingests for Endurance 14

### DIFF
--- a/CE01ISSM/CE01ISSM_R00014_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00014_ingest.csv
@@ -1,0 +1,52 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/cpm3/syslog*/cpm_status.txt,CE01ISSM-MFC31-00-CPMENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/syslog*/*syslog*.log,CE01ISSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+# mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/vel3d*/*vel3d*.log,CE01ISSM-MFD35-01-VEL3DD000,recovered_host,Pending,Error in sensor clock blocking ingests
+# ,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/VEL3D*/*vel3d*.VEC,CE01ISSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this dataset
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/presf*/*presf*.log,CE01ISSM-MFD35-02-PRESFA000,recovered_host,Available,
+mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/PRESF*/*presf*.hex,CE01ISSM-MFD35-02-PRESFA000,recovered_inst,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/adcpt*/*adcpt*.log,CE01ISSM-MFD35-04-ADCPTM000,recovered_host,Available,
+mi.dataset.driver.adcpt_m.adcpt_m_dspec_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/DSpec*.txt,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.adcpt_m.adcpt_m_fcoeff_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/FCoeff*.txt,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.adcpt_m.adcpt_m_log9_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*LOG9.TXT,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.adcpt_m.wvs.adcpt_m_wvs_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*.WVS,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*.PD0,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/pco2w*/*pco2w*.log,CE01ISSM-MFD35-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-MFD35-05-PCO2WB000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/phsen*/*phsen*.log,CE01ISSM-MFD35-06-PHSEND000,recovered_host,Available,
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE01ISSM-MFD35-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl37/syslog*/*syslog*.log,CE01ISSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl37/optaa*/*optaa*.log,CE01ISSM-MFD37-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE01ISSM-MFD37-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE01ISSM-MFD37-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE01ISSM-MFD37-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE01ISSM-MFD37-03-DOSTAD000,recovered_inst,Available,
+# ,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
+# ,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
+# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE01ISSM-RID16-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE01ISSM-RID16-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE01ISSM-RID16-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE01ISSM-RID16-03-DOSTAD000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/velpt*/*velpt*.log,CE01ISSM-RID16-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/VELPT*/*velpt*.aqd,CE01ISSM-RID16-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/pco2w*/*pco2w*.log,CE01ISSM-RID16-05-PCO2WB000,recovered_host,Available,
+# mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-RID16-05-PCO2WB000,recovered_inst,Not Expected,Instrument battery failure
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/phsen*/*phsen*.log,CE01ISSM-RID16-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/PHSEN*/*phsen*recovered*.txt,CE01ISSM-RID16-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/nutnr*/*nutnr*.log,CE01ISSM-RID16-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/NUTNR*/*nutnr*/D*.CSV,CE01ISSM-RID16-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/spkir*/*spkir*.log,CE01ISSM-RID16-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/irid2shore/cpm_status*.txt,CE01ISSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl17/syslog*/*syslog*.log,CE01ISSM-SBD17-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl17/mopak*/*mopak*.log,CE01ISSM-SBD17-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl17/velpt*/*velpt*.log,CE01ISSM-SBD17-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl17/VELPT*/*velpt*.aqd,CE01ISSM-SBD17-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl17/ctdbp*/*ctdbp3.log,CE01ISSM-SBD17-06-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl17/CTDBP*/*ctdbp*.hex,CE01ISSM-SBD17-06-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl17/ctdbp*/*ctdbp3.log,CE01ISSM-SBD17-06-FLORTD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.flort_dj_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl17/CTDBP*/*ctdbp*.hex,CE01ISSM-SBD17-06-FLORTD000,recovered_inst,Available,

--- a/CE01ISSM/CE01ISSM_R00014_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00014_ingest.csv
@@ -5,12 +5,12 @@ parser,filename_mask,reference_designator,data_source,status,notes
 # ,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/VEL3D*/*vel3d*.VEC,CE01ISSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this dataset
 mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/presf*/*presf*.log,CE01ISSM-MFD35-02-PRESFA000,recovered_host,Available,
 mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/PRESF*/*presf*.hex,CE01ISSM-MFD35-02-PRESFA000,recovered_inst,Available,
-mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/adcpt*/*adcpt*.log,CE01ISSM-MFD35-04-ADCPTM000,recovered_host,Available,
-mi.dataset.driver.adcpt_m.adcpt_m_dspec_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/DSpec*.txt,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
-mi.dataset.driver.adcpt_m.adcpt_m_fcoeff_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/FCoeff*.txt,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
-mi.dataset.driver.adcpt_m.adcpt_m_log9_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*LOG9.TXT,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
-mi.dataset.driver.adcpt_m.wvs.adcpt_m_wvs_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*.WVS,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
-mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*.PD0,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+# mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/adcpt*/*adcpt*.log,CE01ISSM-MFD35-04-ADCPTM000,recovered_host,Not Expected,Instrument failed immediately after deployment
+# mi.dataset.driver.adcpt_m.adcpt_m_dspec_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/DSpec*.txt,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Not Expected,Instrument failed immediately after deployment
+# mi.dataset.driver.adcpt_m.adcpt_m_fcoeff_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/FCoeff*.txt,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Not Expected,Instrument failed immediately after deployment
+# mi.dataset.driver.adcpt_m.adcpt_m_log9_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*LOG9.TXT,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Not Expected,Instrument failed immediately after deployment
+# mi.dataset.driver.adcpt_m.wvs.adcpt_m_wvs_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*.WVS,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Not Expected,Instrument failed immediately after deployment
+# mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/ADCPT*/*adcpt*/*.PD0,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Not Expected,Instrument failed immediately after deployment
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/pco2w*/*pco2w*.log,CE01ISSM-MFD35-05-PCO2WB000,recovered_host,Available,
 mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-MFD35-05-PCO2WB000,recovered_inst,Available,
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl36/phsen*/*phsen*.log,CE01ISSM-MFD35-06-PHSEND000,recovered_host,Available,
@@ -29,15 +29,15 @@ mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE01ISSM-RID16-03-CTDBPC000,recovered_host,Available,
-mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE01ISSM-RID16-03-CTDBPC000,recovered_inst,Available,
+# mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE01ISSM-RID16-03-CTDBPC000,recovered_inst,Not Expected,Instrument did not record internally
 mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE01ISSM-RID16-03-DOSTAD000,recovered_host,Available,
-mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE01ISSM-RID16-03-DOSTAD000,recovered_inst,Available,
+# mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE01ISSM-RID16-03-DOSTAD000,recovered_inst,Not Expected,Instrument did not record internally
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/velpt*/*velpt*.log,CE01ISSM-RID16-04-VELPTA000,recovered_host,Available,
 mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/VELPT*/*velpt*.aqd,CE01ISSM-RID16-04-VELPTA000,recovered_inst,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/pco2w*/*pco2w*.log,CE01ISSM-RID16-05-PCO2WB000,recovered_host,Available,
 # mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-RID16-05-PCO2WB000,recovered_inst,Not Expected,Instrument battery failure
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/phsen*/*phsen*.log,CE01ISSM-RID16-06-PHSEND000,recovered_host,Available,
-mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/PHSEN*/*phsen*recovered*.txt,CE01ISSM-RID16-06-PHSEND000,recovered_inst,Available,
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/PHSEN*/*phsen*recovered*.txt,CE01ISSM-RID16-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
 mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/nutnr*/*nutnr*.log,CE01ISSM-RID16-07-NUTNRB000,recovered_host,Available,
 mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl16/NUTNR*/*nutnr*/D*.CSV,CE01ISSM-RID16-07-NUTNRB000,recovered_inst,Available,
 mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/spkir*/*spkir*.log,CE01ISSM-RID16-08-SPKIRB000,recovered_host,Available,

--- a/CE02SHSM/CE02SHSM_R00012_ingest.csv
+++ b/CE02SHSM/CE02SHSM_R00012_ingest.csv
@@ -27,5 +27,5 @@ mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/hyd*/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,recovered_host,Available,
 mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,recovered_host,Available,
 mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,recovered_host,Available,
-# mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,recovered_host,Not Deployed,
-# mi.dataset.driver.fdchp_a.fdchp_a_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl12/FDCHP*/*fdchp*/*/fdchp*.dat,CE02SHSM-SBD12-08-FDCHPA000,recovered_inst,Not Deployed,
+mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,recovered_host,Available,
+mi.dataset.driver.fdchp_a.fdchp_a_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl12/FDCHP*/*fdchp*/*/fdchp*.dat,CE02SHSM-SBD12-08-FDCHPA000,recovered_inst,Available,

--- a/CE02SHSM/CE02SHSM_R00012_ingest.csv
+++ b/CE02SHSM/CE02SHSM_R00012_ingest.csv
@@ -1,0 +1,31 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/cpm2/syslog/cpm_status.txt,CE02SHSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl26/syslog/*.syslog.log,CE02SHSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl26/adcpt/*.adcpt.log,CE02SHSM-RID26-01-ADCPTA000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl26/ADCPT*/*adcpt*.000,CE02SHSM-RID26-01-ADCPTA000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl26/velpt*/*.velpt*.log,CE02SHSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl26/VELPT*/*velpt*.aqd,CE02SHSM-RID26-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl26/phsen/*.phsen.log,CE02SHSM-RID26-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE02SHSM-RID26-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl26/nutnr/*.nutnr.log,CE02SHSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE02SHSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl26/spkir/*.spkir.log,CE02SHSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl27/syslog/*.syslog.log,CE02SHSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl27/optaa/*.optaa.log,CE02SHSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl27/flort/*.flort.log,CE02SHSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl27/ctdbp/*.ctdbp.log,CE02SHSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl27/CTDBP*/*ctdbp*.hex,CE02SHSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl27/dosta/*.dosta.log,CE02SHSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/irid2shore/cpm_status*.txt,CE02SHSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl11/syslog/*.syslog.log,CE02SHSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl11/mopak/*.mopak.log,CE02SHSM-SBD11-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl11/hyd*/*.hyd*.log,CE02SHSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl11/velpt*/*.velpt*.log,CE02SHSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl11/VELPT*/*velpt*.aqd,CE02SHSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl11/metbk/*.metbk.log,CE02SHSM-SBD11-06-METBKA000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/syslog/*.syslog.log,CE02SHSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/hyd*/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,recovered_host,Available,
+# mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,recovered_host,Not Deployed,
+# mi.dataset.driver.fdchp_a.fdchp_a_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00012/instrmts/dcl12/FDCHP*/*fdchp*/*/fdchp*.dat,CE02SHSM-SBD12-08-FDCHPA000,recovered_inst,Not Deployed,

--- a/CE04OSSM/CE04OSSM_R00011_ingest.csv
+++ b/CE04OSSM/CE04OSSM_R00011_ingest.csv
@@ -1,0 +1,29 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/cpm2/syslog/cpm_status.txt,CE04OSSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl26/syslog/*.syslog.log,CE04OSSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl26/adcpt/*.adcpt.log,CE04OSSM-RID26-01-ADCPTC000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/instrmts/dcl26/ADCPT*/*adcpt*.000,CE04OSSM-RID26-01-ADCPTC000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl26/velpt*/*.velpt*.log,CE04OSSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/instrmts/dcl26/VELPT*/*velpt*.aqd,CE04OSSM-RID26-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl26/phsen/*.phsen.log,CE04OSSM-RID26-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE04OSSM-RID26-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl26/nutnr/*.nutnr.log,CE04OSSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE04OSSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl26/spkir/*.spkir.log,CE04OSSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl27/syslog/*.syslog.log,CE04OSSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl27/optaa/*.optaa.log,CE04OSSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl27/flort/*.flort.log,CE04OSSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl27/ctdbp/*.ctdbp.log,CE04OSSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/instrmts/dcl27/CTDBP*/*ctdbp*.hex,CE04OSSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl27/dosta/*.dosta.log,CE04OSSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/irid2shore/cpm_status*.txt,CE04OSSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl11/syslog/*.syslog.log,CE04OSSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl11/mopak/*.mopak.log,CE04OSSM-SBD11-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl11/hyd*/*.hyd*.log,CE04OSSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl11/velpt*/*.velpt*.log,CE04OSSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/instrmts/dcl11/VELPT*/*velpt*.aqd,CE04OSSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl12/syslog/*.syslog.log,CE04OSSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl12/hyd*/*.hyd*.log,CE04OSSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00011/cg_data/dcl12/wavss/*.wavss.log,CE04OSSM-SBD12-05-WAVSSA000,recovered_host,Available,

--- a/CE06ISSM/CE06ISSM_R00013_ingest.csv
+++ b/CE06ISSM/CE06ISSM_R00013_ingest.csv
@@ -12,7 +12,7 @@ mi.dataset.driver.adcpt_m.adcpt_m_log9_recovered_driver,/omc_data/whoi/OMC/CE06I
 mi.dataset.driver.adcpt_m.wvs.adcpt_m_wvs_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/ADCPT*/*adcpt*/*.WVS,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
 mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/ADCPT*/*adcpt*/*.PD0,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl36/pco2w*/*pco2w*.log,CE06ISSM-MFD35-05-PCO2WB000,recovered_host,Available,
-mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE06ISSM-MFD35-05-PCO2WB000,recovered_inst,Available,
+# mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE06ISSM-MFD35-05-PCO2WB000,recovered_inst,Not Expected,Instrument non-responsive
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl36/phsen*/*phsen*.log,CE06ISSM-MFD35-06-PHSEND000,recovered_host,Available,
 mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE06ISSM-MFD35-06-PHSEND000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl37/syslog*/*syslog*.log,CE06ISSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
@@ -35,7 +35,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/velpt*/*velpt*.log,CE06ISSM-RID16-04-VELPTA000,recovered_host,Available,
 mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/VELPT*/*velpt*.aqd,CE06ISSM-RID16-04-VELPTA000,recovered_inst,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/pco2w*/*pco2w*.log,CE06ISSM-RID16-05-PCO2WB000,recovered_host,Available,
-mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE06ISSM-RID16-05-PCO2WB000,recovered_inst,Available,
+# mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE06ISSM-RID16-05-PCO2WB000,recovered_inst,Not Expected,Internal battery pack failure
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/phsen*/*phsen*.log,CE06ISSM-RID16-06-PHSEND000,recovered_host,Available,
 mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/PHSEN*/*phsen*recovered*.txt,CE06ISSM-RID16-06-PHSEND000,recovered_inst,Available,
 mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/nutnr*/*nutnr*.log,CE06ISSM-RID16-07-NUTNRB000,recovered_host,Available,

--- a/CE06ISSM/CE06ISSM_R00013_ingest.csv
+++ b/CE06ISSM/CE06ISSM_R00013_ingest.csv
@@ -1,0 +1,52 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/cpm3/syslog*/cpm_status.txt,CE06ISSM-MFC31-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl36/syslog*/*syslog*.log,CE06ISSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl36/vel3d*/*vel3d*.log,CE06ISSM-MFD35-01-VEL3DD000,recovered_host,Pending,Error in sensor clock blocking ingests
+# ,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/VEL3D*/*vel3d*.VEC,CE06ISSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this dataset
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl36/presf*/*presf*.log,CE06ISSM-MFD35-02-PRESFA000,recovered_host,Available,
+mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/PRESF*/*presf*.hex,CE06ISSM-MFD35-02-PRESFA000,recovered_inst,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl36/adcpt*/*adcpt*.log,CE06ISSM-MFD35-04-ADCPTM000,recovered_host,Available,
+mi.dataset.driver.adcpt_m.adcpt_m_dspec_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/ADCPT*/*adcpt*/DSpec*.txt,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.adcpt_m.adcpt_m_fcoeff_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/ADCPT*/*adcpt*/FCoeff*.txt,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.adcpt_m.adcpt_m_log9_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/ADCPT*/*adcpt*/*LOG9.TXT,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.adcpt_m.wvs.adcpt_m_wvs_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/ADCPT*/*adcpt*/*.WVS,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/ADCPT*/*adcpt*/*.PD0,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl36/pco2w*/*pco2w*.log,CE06ISSM-MFD35-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE06ISSM-MFD35-05-PCO2WB000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl36/phsen*/*phsen*.log,CE06ISSM-MFD35-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE06ISSM-MFD35-06-PHSEND000,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl37/syslog*/*syslog*.log,CE06ISSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl37/optaa*/*optaa*.log,CE06ISSM-MFD37-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE06ISSM-MFD37-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE06ISSM-MFD37-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE06ISSM-MFD37-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE06ISSM-MFD37-03-DOSTAD000,recovered_inst,Available,
+# ,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl37/camds/*.png,CE06ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
+# ,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE06ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl37/zplsc/*zplsc.log,CE06ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
+# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE06ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/syslog*/*syslog*.log,CE06ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/optaa*/*optaa*.log,CE06ISSM-RID16-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/flort*/*flort*.log,CE06ISSM-RID16-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE06ISSM-RID16-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE06ISSM-RID16-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE06ISSM-RID16-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE06ISSM-RID16-03-DOSTAD000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/velpt*/*velpt*.log,CE06ISSM-RID16-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/VELPT*/*velpt*.aqd,CE06ISSM-RID16-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/pco2w*/*pco2w*.log,CE06ISSM-RID16-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE06ISSM-RID16-05-PCO2WB000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/phsen*/*phsen*.log,CE06ISSM-RID16-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/PHSEN*/*phsen*recovered*.txt,CE06ISSM-RID16-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/nutnr*/*nutnr*.log,CE06ISSM-RID16-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl16/NUTNR*/*nutnr*/D*.CSV,CE06ISSM-RID16-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl16/spkir*/*spkir*.log,CE06ISSM-RID16-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/irid2shore/cpm_status*.txt,CE06ISSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl17/syslog*/*syslog*.log,CE06ISSM-SBD17-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl17/mopak*/*mopak*.log,CE06ISSM-SBD17-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl17/velpt*/*velpt*.log,CE06ISSM-SBD17-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl17/VELPT*/*velpt*.aqd,CE06ISSM-SBD17-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl17/ctdbp*/*ctdbp3.log,CE06ISSM-SBD17-06-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl17/CTDBP*/*ctdbp*.hex,CE06ISSM-SBD17-06-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/cg_data/dcl17/ctdbp*/*ctdbp3.log,CE06ISSM-SBD17-06-FLORTD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.flort_dj_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00013/instrmts/dcl17/CTDBP*/*ctdbp*.hex,CE06ISSM-SBD17-06-FLORTD000,recovered_inst,Available,

--- a/CE07SHSM/CE07SHSM_R00012_ingest.csv
+++ b/CE07SHSM/CE07SHSM_R00012_ingest.csv
@@ -1,0 +1,51 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/cpm3/syslog/cpm_status.txt,CE07SHSM-MFC31-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/syslog/*.syslog.log,CE07SHSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/vel3d/*.vel3d.log,CE07SHSM-MFD35-01-VEL3DD000,recovered_host,Pending,Error in sensor clock blocking ingests
+# ,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/VEL3D*/*vel3d*.VEC,CE07SHSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this dataset
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/presf/*.presf.log,CE07SHSM-MFD35-02-PRESFB000,recovered_host,Available,
+mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PRESF*/*presf*.hex,CE07SHSM-MFD35-02-PRESFB000,recovered_inst,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/adcpt2/*.adcpt*.log,CE07SHSM-MFD35-04-ADCPTC000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/ADCPT*/*.000,CE07SHSM-MFD35-04-ADCPTC000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/pco2w/*.pco2w.log,CE07SHSM-MFD35-05-PCO2WB000,recovered_host,Available,
+# mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE07SHSM-MFD35-05-PCO2WB000,recovered_inst,Not Expected,Instrument battery failure
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/phsen2/*.phsen*.log,CE07SHSM-MFD35-06-PHSEND000,recovered_host,Available,
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE07SHSM-MFD35-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/syslog/*.syslog.log,CE07SHSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/optaa2/*.optaa*.log,CE07SHSM-MFD37-01-OPTAAD000,recovered_host,Not Deployed,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/ctdbp2/*.ctdbp*.log,CE07SHSM-MFD37-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE07SHSM-MFD37-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/ctdbp2/*.ctdbp*.log,CE07SHSM-MFD37-03-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE07SHSM-MFD37-03-DOSTAD000,recovered_inst,Not Available,Instument damaged at sea
+# ,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/camds/*.png,CE07SHSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
+# ,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl37/CAMDS_*/*camds*/DCIM/*.png,CE07SHSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/zplsc/*.zplsc.log,CE07SHSM-MFD37-07-ZPLSCC000,recovered_host,Available,
+# ,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE07SHSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/cpm2/syslog/cpm_status.txt,CE07SHSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/syslog/*.syslog.log,CE07SHSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/adcpt1/*.adcpt*.log,CE07SHSM-RID26-01-ADCPTA000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl26/ADCPT*/*adcpt*.000,CE07SHSM-RID26-01-ADCPTA000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/velpt2/*.velpt*.log,CE07SHSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl26/VELPT*/*velpt*.aqd,CE07SHSM-RID26-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/phsen*/*.phsen*.log,CE07SHSM-RID26-06-PHSEND000,recovered_host,Available,
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE07SHSM-RID26-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/nutnr/*.nutnr.log,CE07SHSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE07SHSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/spkir/*.spkir.log,CE07SHSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl27/syslog/*.syslog.log,CE07SHSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl27/optaa1/*.optaa*.log,CE07SHSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl27/flort/*.flort.log,CE07SHSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl27/ctdbp1/*.ctdbp*.log,CE07SHSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl27/CTDBP*/*ctdbp*.hex,CE07SHSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl27/dosta/*.dosta.log,CE07SHSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/irid2shore/cpm_status*.txt,CE07SHSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/syslog/*.syslog.log,CE07SHSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/mopak/*.mopak.log,CE07SHSM-SBD11-01-MOPAK0000,recovered_host,Missing,Had to remove at-sea to create space on disk
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/hyd1/*.hyd1.log,CE07SHSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/velpt1/*.velpt1.log,CE07SHSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl11/VELPT*/*velpt*.aqd,CE07SHSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/metbk/*.metbk.log,CE07SHSM-SBD11-06-METBKA000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl12/syslog/*.syslog.log,CE07SHSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl12/hyd2/*.hyd2.log,CE07SHSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl12/wavss/*.wavss.log,CE07SHSM-SBD12-05-WAVSSA000,recovered_host,Available,

--- a/CE07SHSM/CE07SHSM_R00012_ingest.csv
+++ b/CE07SHSM/CE07SHSM_R00012_ingest.csv
@@ -3,20 +3,20 @@ parser,filename_mask,reference_designator,data_source,status,notes
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/syslog/*.syslog.log,CE07SHSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
 # mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/vel3d/*.vel3d.log,CE07SHSM-MFD35-01-VEL3DD000,recovered_host,Pending,Error in sensor clock blocking ingests
 # ,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/VEL3D*/*vel3d*.VEC,CE07SHSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this dataset
-mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/presf/*.presf.log,CE07SHSM-MFD35-02-PRESFB000,recovered_host,Available,
-mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PRESF*/*presf*.hex,CE07SHSM-MFD35-02-PRESFB000,recovered_inst,Available,
+# mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/presf/*.presf.log,CE07SHSM-MFD35-02-PRESFB000,recovered_host,Not Expected,Battery failure
+# mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PRESF*/*presf*.hex,CE07SHSM-MFD35-02-PRESFB000,recovered_inst,Not Expected,Battery failure
 mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/adcpt2/*.adcpt*.log,CE07SHSM-MFD35-04-ADCPTC000,recovered_host,Available,
 mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/ADCPT*/*.000,CE07SHSM-MFD35-04-ADCPTC000,recovered_inst,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/pco2w/*.pco2w.log,CE07SHSM-MFD35-05-PCO2WB000,recovered_host,Available,
-# mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE07SHSM-MFD35-05-PCO2WB000,recovered_inst,Not Expected,Instrument battery failure
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE07SHSM-MFD35-05-PCO2WB000,recovered_inst,Available,
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl36/phsen2/*.phsen*.log,CE07SHSM-MFD35-06-PHSEND000,recovered_host,Available,
-# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE07SHSM-MFD35-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE07SHSM-MFD35-06-PHSEND000,recovered_inst,Not Expected,Instrument flooded
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/syslog/*.syslog.log,CE07SHSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/optaa2/*.optaa*.log,CE07SHSM-MFD37-01-OPTAAD000,recovered_host,Not Deployed,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/ctdbp2/*.ctdbp*.log,CE07SHSM-MFD37-03-CTDBPC000,recovered_host,Available,
 mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE07SHSM-MFD37-03-CTDBPC000,recovered_inst,Available,
 mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/ctdbp2/*.ctdbp*.log,CE07SHSM-MFD37-03-DOSTAD000,recovered_host,Available,
-# mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE07SHSM-MFD37-03-DOSTAD000,recovered_inst,Not Available,Instument damaged at sea
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE07SHSM-MFD37-03-DOSTAD000,recovered_inst,Available,
 # ,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/camds/*.png,CE07SHSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl37/CAMDS_*/*camds*/DCIM/*.png,CE07SHSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl37/zplsc/*.zplsc.log,CE07SHSM-MFD37-07-ZPLSCC000,recovered_host,Available,
@@ -28,7 +28,7 @@ mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/velpt2/*.velpt*.log,CE07SHSM-RID26-04-VELPTA000,recovered_host,Available,
 mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl26/VELPT*/*velpt*.aqd,CE07SHSM-RID26-04-VELPTA000,recovered_inst,Available,
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/phsen*/*.phsen*.log,CE07SHSM-RID26-06-PHSEND000,recovered_host,Available,
-# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE07SHSM-RID26-06-PHSEND000,recovered_inst,Not Expected,Instrument battery failure
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE07SHSM-RID26-06-PHSEND000,recovered_inst,Available,
 mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/nutnr/*.nutnr.log,CE07SHSM-RID26-07-NUTNRB000,recovered_host,Available,
 mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE07SHSM-RID26-07-NUTNRB000,recovered_inst,Available,
 mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl26/spkir/*.spkir.log,CE07SHSM-RID26-08-SPKIRB000,recovered_host,Available,
@@ -40,7 +40,7 @@ mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE07
 mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl27/dosta/*.dosta.log,CE07SHSM-RID27-04-DOSTAD000,recovered_host,Available,
 # mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/irid2shore/cpm_status*.txt,CE07SHSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/syslog/*.syslog.log,CE07SHSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
-# mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/mopak/*.mopak.log,CE07SHSM-SBD11-01-MOPAK0000,recovered_host,Missing,Had to remove at-sea to create space on disk
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/mopak/*.mopak.log,CE07SHSM-SBD11-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/hyd1/*.hyd1.log,CE07SHSM-SBD11-02-HYDGN0000,recovered_host,Available,
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/cg_data/dcl11/velpt1/*.velpt1.log,CE07SHSM-SBD11-04-VELPTA000,recovered_host,Available,
 mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00012/instrmts/dcl11/VELPT*/*velpt*.aqd,CE07SHSM-SBD11-04-VELPTA000,recovered_inst,Available,

--- a/CE09OSPM/CE09OSPM_R00014_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00014_ingest.csv
@@ -1,0 +1,8 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
+mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
+mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,
+mi.dataset.driver.ctdpf_ckl.wfp.coastal_ctdpf_ckl_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-03-CTDPFK000,recovered_wfp,Available,
+mi.dataset.driver.flort_kn.stc_imodem.flort_kn__stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-04-FLORTK000,recovered_wfp,Available,
+mi.dataset.driver.PARAD_K.STC_IMODEM.parad_k_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-05-PARADK000,recovered_wfp,Available,

--- a/CE09OSSM/CE09OSSM_R00012_ingest.csv
+++ b/CE09OSSM/CE09OSSM_R00012_ingest.csv
@@ -1,0 +1,51 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/cpm3/syslog/cpm_status.txt,CE09OSSM-MFC31-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl36/syslog/*.syslog.log,CE09OSSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl36/vel3d/*.vel3d.log,CE09OSSM-MFD35-01-VEL3DD000,recovered_host,Pending,Error in sensor clock blocking ingests
+# ,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl36/VEL3D*/*.VEC,CE09OSSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl36/presf/*.presf.log,CE09OSSM-MFD35-02-PRESFC000,recovered_host,Available,
+mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl36/PRESF*/*presf*.hex,CE09OSSM-MFD35-02-PRESFC000,recovered_inst,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl36/adcps/*.adcps.log,CE09OSSM-MFD35-04-ADCPSJ000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl36/ADCPS*/*.000,CE09OSSM-MFD35-04-ADCPSJ000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl36/pco2w/*.pco2w.log,CE09OSSM-MFD35-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE09OSSM-MFD35-05-PCO2WB000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl36/phsen2/*.phsen2.log,CE09OSSM-MFD35-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE09OSSM-MFD35-06-PHSEND000,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl37/syslog/*.syslog.log,CE09OSSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl37/optaa2/*.optaa2.log,CE09OSSM-MFD37-01-OPTAAC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl37/ctdbp2/*.ctdbp2.log,CE09OSSM-MFD37-03-CTDBPE000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE09OSSM-MFD37-03-CTDBPE000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl37/ctdbp2/*.ctdbp2.log,CE09OSSM-MFD37-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE09OSSM-MFD37-03-DOSTAD000,recovered_inst,Available,
+# ,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl37/camds/*.png,CE09OSSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
+# ,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl37/CAMDS_*/*camds*/dcim/*.png,CE09OSSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
+# mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl37/zplsc/*.zplsc.log,CE09OSSM-MFD37-07-ZPLSCC000,recovered_host,Not Deployed,
+# ,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE09OSSM-MFD37-07-ZPLSCC000,recovered_inst,Not Deployed,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/cpm2/syslog/cpm_status.txt,CE09OSSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl26/syslog/*.syslog.log,CE09OSSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl26/adcpt*/*.adcpt.log,CE09OSSM-RID26-01-ADCPTC000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl26/ADCPT*/*adcpt*.000,CE09OSSM-RID26-01-ADCPTC000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl26/velpt2/*.velpt2.log,CE09OSSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl26/VELPT*/*velpt*.aqd,CE09OSSM-RID26-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl26/phsen*/*.phsen*.log,CE09OSSM-RID26-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE09OSSM-RID26-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl26/nutnr*/*.nutnr.log,CE09OSSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE09OSSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl26/spkir*/*.spkir.log,CE09OSSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl27/syslog/*.syslog.log,CE09OSSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl27/optaa1/*.optaa1.log,CE09OSSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl27/flort/*.flort.log,CE09OSSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl27/ctdbp1/*.ctdbp1.log,CE09OSSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl27/CTDBP*/*.hex,CE09OSSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl27/dosta/*.dosta.log,CE09OSSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/irid2shore/cpm_status.*.txt,CE09OSSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl11/syslog/*.syslog.log,CE09OSSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl11/mopak/*.mopak.log,CE09OSSM-SBD11-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl11/hyd1/*.log,CE09OSSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl11/velpt1/*.velpt1.log,CE09OSSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/instrmts/dcl11/VELPT*/*velpt*.aqd,CE09OSSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl11/metbk/*.metbk.log,CE09OSSM-SBD11-06-METBKA000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl12/syslog/*.syslog.log,CE09OSSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl12/hyd2/*.log,CE09OSSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00012/cg_data/dcl12/wavss/*.wavss.log,CE09OSSM-SBD12-05-WAVSSA000,recovered_host,Available,


### PR DESCRIPTION
Ingest sheets for the recovered data from Endurance 14. Excluding data from the failed pH and pCO2 sensors, the 01 ADCP and the 07 PRESF.