### PR TITLE
Endurance 18 Gliders and As-Deployed Mooring Updates

### DIFF
--- a/CE01ISSM/CE01ISSM_D00018_ingest.csv
+++ b/CE01ISSM/CE01ISSM_D00018_ingest.csv
@@ -5,7 +5,7 @@ mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl36/presf/*.presf.log,CE01ISSM-MFD35-02-PRESFA000,telemetered,Available,
 mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl36/adcpt/*.adcpt.log,CE01ISSM-MFD35-04-ADCPTM000,telemetered,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl36/pco2w*/*.pco2w*.log,CE01ISSM-MFD35-05-PCO2WB000,telemetered,Available,
-mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl36/phsen*/*.phsen*.log,CE01ISSM-MFD35-06-PHSEND000,telemetered,Available,
+# mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl36/phsen*/*.phsen*.log,CE01ISSM-MFD35-06-PHSEND000,telemetered,Not Deployed,Not returned from the vendor in time
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl37/syslog/*.syslog.log,CE01ISSM-MFD37-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl37/optaa*/*.optaa*.log,CE01ISSM-MFD37-01-OPTAAD000,telemetered,Available,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE01ISSM-MFD37-03-CTDBPC000,telemetered,Available,
@@ -17,7 +17,7 @@ mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl16/flort/*.flort.log,CE01ISSM-RID16-02-FLORTD000,telemetered,Available,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl16/ctdbp*/*.ctdbp*.log,CE01ISSM-RID16-03-CTDBPC000,telemetered,Available,
 mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl16/ctdbp*/*.ctdbp*.log,CE01ISSM-RID16-03-DOSTAD000,telemetered,Available,
-mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl16/velpt*/*.velpt*.log,CE01ISSM-RID16-04-VELPTA000,telemetered,Available,
+# mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl16/velpt*/*.velpt*.log,CE01ISSM-RID16-04-VELPTA000,telemetered,Missing,No data recorded by the DCL
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl16/pco2w*/*.pco2w*.log,CE01ISSM-RID16-05-PCO2WB000,telemetered,Available,
 mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl16/phsen*/*.phsen*.log,CE01ISSM-RID16-06-PHSEND000,telemetered,Available,
 mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl16/nutnr/*.nutnr.log,CE01ISSM-RID16-07-NUTNRB000,telemetered,Available,
@@ -27,4 +27,4 @@ mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE01ISSM-SBD17-06-CTDBPC000,telemetered,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE01ISSM-SBD17-06-FLORTD000,telemetered,Available,
 mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl17/mopak/*.mopak.log,CE01ISSM-SBD17-01-MOPAK0000,telemetered,Available,
-mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl17/velpt*/*.velpt*.log,CE01ISSM-SBD17-04-VELPTA000,telemetered,Available,
+# mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/D00018/cg_data/dcl17/velpt*/*.velpt*.log,CE01ISSM-SBD17-04-VELPTA000,telemetered,Missing,No data recorded by the DCL

--- a/CE05MOAS-G0917/CE05MOAS-G0917_D00005_ingest.csv
+++ b/CE05MOAS-G0917/CE05MOAS-G0917_D00005_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-G0917-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-G0917-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-G0917-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-G0917-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/D00005/merged-from-glider/ce_*.mrg,CE05MOAS-G0917-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-G0917/CE05MOAS-G0917_R00005_ingest.csv
+++ b/CE05MOAS-G0917/CE05MOAS-G0917_R00005_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/R00005/merged/ce_*.full.mrg,CE05MOAS-G0917-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/R00005/merged/ce_*.full.mrg,CE05MOAS-G0917-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/R00005/merged/ce_*.full.mrg,CE05MOAS-G0917-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/R00005/dvl/*.pd0,CE05MOAS-G0917-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/R00005/merged/ce_*.full.mrg,CE05MOAS-G0917-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-G0917/R00005/merged/ce_*.full.mrg,CE05MOAS-G0917-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL312/CE05MOAS-GL312_D00014_ingest.csv
+++ b/CE05MOAS-GL312/CE05MOAS-GL312_D00014_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00014/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00014/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00014/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00014/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/D00014/merged-from-glider/ce_*.mrg,CE05MOAS-GL312-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL312/CE05MOAS-GL312_R00014_ingest.csv
+++ b/CE05MOAS-GL312/CE05MOAS-GL312_R00014_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00014/merged/ce_*.full.mrg,CE05MOAS-GL312-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00014/merged/ce_*.full.mrg,CE05MOAS-GL312-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00014/merged/ce_*.full.mrg,CE05MOAS-GL312-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00014/dvl/*.pd0,CE05MOAS-GL312-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00014/merged/ce_*.full.mrg,CE05MOAS-GL312-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL312/R00014/merged/ce_*.full.mrg,CE05MOAS-GL312-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL319/CE05MOAS-GL319_D00013_ingest.csv
+++ b/CE05MOAS-GL319/CE05MOAS-GL319_D00013_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/D00013/merged-from-glider/ce_*.mrg,CE05MOAS-GL319-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/D00013/merged-from-glider/ce_*.mrg,CE05MOAS-GL319-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/D00013/merged-from-glider/ce_*.mrg,CE05MOAS-GL319-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/D00013/merged-from-glider/ce_*.mrg,CE05MOAS-GL319-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/D00013/merged-from-glider/ce_*.mrg,CE05MOAS-GL319-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL319/CE05MOAS-GL319_R00013_ingest.csv
+++ b/CE05MOAS-GL319/CE05MOAS-GL319_R00013_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00013/merged/ce_*.full.mrg,CE05MOAS-GL319-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00013/merged/ce_*.full.mrg,CE05MOAS-GL319-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00013/merged/ce_*.full.mrg,CE05MOAS-GL319-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00013/dvl/*.pd0,CE05MOAS-GL319-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00013/merged/ce_*.full.mrg,CE05MOAS-GL319-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL319/R00013/merged/ce_*.full.mrg,CE05MOAS-GL319-05-CTDGVM000,recovered_host,Available,

--- a/CE05MOAS-GL381/CE05MOAS-GL381_D00011_ingest.csv
+++ b/CE05MOAS-GL381/CE05MOAS-GL381_D00011_ingest.csv
@@ -1,0 +1,6 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL381-00-ENG000000,telemetered,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL381-01-PARADM000,telemetered,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL381-02-FLORTM000,telemetered,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL381-04-DOSTAM000,telemetered,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_telemetered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/D00011/merged-from-glider/ce_*.mrg,CE05MOAS-GL381-05-CTDGVM000,telemetered,Available,

--- a/CE05MOAS-GL381/CE05MOAS-GL381_R00011_ingest.csv
+++ b/CE05MOAS-GL381/CE05MOAS-GL381_R00011_ingest.csv
@@ -1,0 +1,7 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.moas.gl.engineering.glider_eng_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/R00011/merged/ce_*.full.mrg,CE05MOAS-GL381-00-ENG000000,recovered_host,Available,
+mi.dataset.driver.moas.gl.parad.parad_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/R00011/merged/ce_*.full.mrg,CE05MOAS-GL381-01-PARADM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.flort_m.flort_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/R00011/merged/ce_*.full.mrg,CE05MOAS-GL381-02-FLORTM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.adcpa.adcpa_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/R00011/dvl/*.pd0,CE05MOAS-GL381-03-ADCPAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.dosta.dosta_abcdjm_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/R00011/merged/ce_*.full.mrg,CE05MOAS-GL381-04-DOSTAM000,recovered_host,Available,
+mi.dataset.driver.moas.gl.ctdgv.ctdgv_m_glider_recovered_driver,/omc_data/whoi/OMC/CE05MOAS-GL381/R00011/merged/ce_*.full.mrg,CE05MOAS-GL381-05-CTDGVM000,recovered_host,Available,

--- a/CE06ISSM/CE06ISSM_D00017_ingest.csv
+++ b/CE06ISSM/CE06ISSM_D00017_ingest.csv
@@ -27,4 +27,4 @@ mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00017/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE06ISSM-SBD17-06-CTDBPC000,telemetered,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00017/cg_data/dcl17/ctdbp*/*.ctdbp*.log,CE06ISSM-SBD17-06-FLORTD000,telemetered,Available,
 mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00017/cg_data/dcl17/mopak/*.mopak.log,CE06ISSM-SBD17-01-MOPAK0000,telemetered,Available,
-mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00017/cg_data/dcl17/velpt1/*.velpt*.log,CE06ISSM-SBD17-04-VELPTA000,telemetered,Available,
+# mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00017/cg_data/dcl17/velpt1/*.velpt*.log,CE06ISSM-SBD17-04-VELPTA000,telemetered,Missing,No data recorded by the DCL

--- a/CE09OSSM/CE09OSSM_D00016_ingest.csv
+++ b/CE09OSSM/CE09OSSM_D00016_ingest.csv
@@ -5,7 +5,7 @@ mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_telemetered_driver,/omc_data/whoi/OM
 mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00016/cg_data/dcl36/presf/*.presf.log,CE09OSSM-MFD35-02-PRESFC000,telemetered,Available,
 mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00016/cg_data/dcl36/adcps/*.adcps.log,CE09OSSM-MFD35-04-ADCPSJ000,telemetered,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00016/cg_data/dcl36/pco2w/*.pco2w.log,CE09OSSM-MFD35-05-PCO2WB000,telemetered,Available,
-mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00016/cg_data/dcl36/phsen*/*.phsen*.log,CE09OSSM-MFD35-06-PHSEND000,telemetered,Available,
+# mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00016/cg_data/dcl36/phsen*/*.phsen*.log,CE09OSSM-MFD35-06-PHSEND000,telemetered,Not Deployed,Not returned from the vendor in time
 mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00016/cg_data/dcl37/syslog/*.syslog.log,CE09OSSM-MFD37-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00016/cg_data/dcl37/optaa*/*.optaa*.log,CE09OSSM-MFD37-01-OPTAAC000,telemetered,Available,
 mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/D00016/cg_data/dcl37/ctdbp*/*.ctdbp*.log,CE09OSSM-MFD37-03-CTDBPE000,telemetered,Available,


### PR DESCRIPTION
Adds ingest sheets for the deployed gliders (sans 1012) and adjusts mooring CSVs for as-deployed.