### PR TITLE
Adds recovered_inst ingest info for the CE01ISSM ZPLSC

### DIFF
--- a/CE01ISSM/CE01ISSM_R00003_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00003_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00003/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00003/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00003/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00003/instrmts/dcl37/ZPLSC_*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00003/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00003/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 # mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00003/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Not Deployed,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00003/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00004_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00004_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00004/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Not Deployed,
 # ,/omc_data/whoi/OMC/CE01ISSM/R00004/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Not Deployed,
 # mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00004/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Not Expected,Internal instrument logging only
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00004/instrmts/dcl37/ZPLSC_*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00004/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00004/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00004/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Not Deployed,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00004/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00005_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00005_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00005/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Not Deployed,
 # ,/omc_data/whoi/OMC/CE01ISSM/R00005/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Not Deployed,
 # mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00005/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Not Expected,Internal instrument logging only
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00005/instrmts/dcl37/ZPLSC_*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00005/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00005/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00005/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Not Deployed,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00005/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00006_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00006_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00006/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00006/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00006/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00006/instrmts/dcl37/ZPLSC_*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00006/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00006/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 # mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00006/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Not Deployed,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00006/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00007_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00007_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00007/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00007/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00007/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00007/instrmts/dcl37/ZPLSC_*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00007/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00007/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00007/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00007/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00008_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00008_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00008/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00008/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00008/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00008/instrmts/dcl37/ZPLSC_*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00008/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00008/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00008/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00008/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00009_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00009_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00009/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00009/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00009/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00009/instrmts/dcl37/ZPLSC_*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00009/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00009/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00009/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00009/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00010_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00010_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00010/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00010/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 # mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00010/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Not Expected,DCL SD card is corrupted
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00010/instrmts/dcl37/ZPLSC_*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00010/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00010/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00010/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00010/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00011_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00011_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00011/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00011/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00011/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00011/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00011/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00011/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00011/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00011/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00012_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00012_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00012/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00012/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00012/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00012/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00012/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00012/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00012/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00012/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00013_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00013_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00013/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00013/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00014_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00014_ingest.csv
@@ -25,7 +25,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00014/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00014/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00015_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00015_ingest.csv
@@ -24,7 +24,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00015/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00015/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00015/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00015/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00015/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00015/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00015/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00015/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00016_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00016_ingest.csv
@@ -24,7 +24,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00016/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00016/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00016/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00016/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00016/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00016/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00016/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00016/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,

--- a/CE01ISSM/CE01ISSM_R00017_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00017_ingest.csv
@@ -24,7 +24,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_da
 # ,/omc_data/whoi/OMC/CE01ISSM/R00017/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
 # ,/omc_data/whoi/OMC/CE01ISSM/R00017/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
 mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00017/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
-# mi.dataset.driver.zplsc_c.zplsc_c_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00017/instrmts/dcl37/ZPLSC*/DATA/*/*.01A,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Pending,System incapable of handling dataset
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00017/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00017/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
 mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00017/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
 mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00017/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,


### PR DESCRIPTION
Quick updates to add the ZPLSC recovered echograms to the ingests for CE01ISSM starting with deployment 3.