### PR TITLE
Endurance 19 Recovered Ingest Sheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.python-version
 .DS_Store
 .idea
+.vscode

--- a/CE01ISSM/CE01ISSM_R00019_ingest.csv
+++ b/CE01ISSM/CE01ISSM_R00019_ingest.csv
@@ -1,0 +1,52 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/cpm3/syslog*/cpm_status.txt,CE01ISSM-MFC31-00-CPMENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl36/syslog*/*syslog*.log,CE01ISSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl36/vel3d*/*vel3d*.log,CE01ISSM-MFD35-01-VEL3DD000,recovered_host,Available,
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl36/presf*/*presf*.log,CE01ISSM-MFD35-02-PRESFA000,recovered_host,Available,
+mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/PRESF*/*presf*.hex,CE01ISSM-MFD35-02-PRESFA000,recovered_inst,Available,
+mi.dataset.driver.presf_abc.presf_abc_wave_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/PRESF*/*presf*.hex,CE01ISSM-MFD35-02-PRESFA000,recovered_inst,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl36/adcpt*/*adcpt*.log,CE01ISSM-MFD35-04-ADCPTM000,recovered_host,Available,
+# mi.dataset.driver.adcpt_m.adcpt_m_dspec_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/ADCPT*/*adcpt*/DSpec*.txt,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Pending,Updated processing application with reviews required
+# mi.dataset.driver.adcpt_m.adcpt_m_fcoeff_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/ADCPT*/*adcpt*/Coeffs*.txt,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Pending,Updated processing application with reviews required
+# mi.dataset.driver.adcpt_m.adcpt_m_log9_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/ADCPT*/*adcpt*/*LogData.000,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Pending,Updated processing application with reviews required
+# mi.dataset.driver.adcpt_m.wvs.adcpt_m_wvs_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/ADCPT*/*adcpt*/*.wvs,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Pending,Updated processing application with reviews required
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/ADCPT*/*adcpt*/*CurrentsData.000,CE01ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl36/pco2w*/*pco2w*.log,CE01ISSM-MFD35-05-PCO2WB000,recovered_host,Available,
+# mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-MFD35-05-PCO2WB000,recovered_inst,Not Expected,Instrument flooded sometime during the deployment
+# mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl36/phsen*/*phsen*.log,CE01ISSM-MFD35-06-PHSEND000,recovered_host,Not Deployed,Instrument not returned from vendor in time for deployment
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE01ISSM-MFD35-06-PHSEND000,recovered_inst,Not Deployed,Instrument not returned from vendor in time for deployment
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl37/syslog*/*syslog*.log,CE01ISSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl37/optaa*/*optaa*.log,CE01ISSM-MFD37-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE01ISSM-MFD37-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE01ISSM-MFD37-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE01ISSM-MFD37-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE01ISSM-MFD37-03-DOSTAD000,recovered_inst,Available,
+# ,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl37/camds/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
+# ,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE01ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl37/zplsc/*zplsc.log,CE01ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE01ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/syslog*/*syslog*.log,CE01ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/optaa*/*optaa*.log,CE01ISSM-RID16-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/flort*/*flort*.log,CE01ISSM-RID16-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE01ISSM-RID16-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE01ISSM-RID16-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE01ISSM-RID16-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE01ISSM-RID16-03-DOSTAD000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/velpt*/*velpt*.log,CE01ISSM-RID16-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl16/VELPT*/*velpt*.aqd,CE01ISSM-RID16-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/pco2w*/*pco2w*.log,CE01ISSM-RID16-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE01ISSM-RID16-05-PCO2WB000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/phsen*/*phsen*.log,CE01ISSM-RID16-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl16/PHSEN*/*phsen*recovered*.txt,CE01ISSM-RID16-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/nutnr*/*nutnr*.log,CE01ISSM-RID16-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl16/NUTNR*/*nutnr*/D*.CSV,CE01ISSM-RID16-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl16/spkir*/*spkir*.log,CE01ISSM-RID16-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/irid2shore/cpm_status*.txt,CE01ISSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl17/syslog*/*syslog*.log,CE01ISSM-SBD17-00-DCLENG000,recovered_host,Pending,Incorrectly specified driver and dataset
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl17/mopak*/*mopak*.log,CE01ISSM-SBD17-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl17/velpt*/*velpt*.log,CE01ISSM-SBD17-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl17/VELPT*/*velpt*.aqd,CE01ISSM-SBD17-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl17/ctdbp*/*ctdbp3.log,CE01ISSM-SBD17-06-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl17/CTDBP*/*ctdbp*.hex,CE01ISSM-SBD17-06-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/cg_data/dcl17/ctdbp*/*ctdbp3.log,CE01ISSM-SBD17-06-FLORTD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.flort_dj_recovered_driver,/omc_data/whoi/OMC/CE01ISSM/R00019/instrmts/dcl17/CTDBP*/*ctdbp*.hex,CE01ISSM-SBD17-06-FLORTD000,recovered_inst,Available,

--- a/CE02SHSM/CE02SHSM_R00017_ingest.csv
+++ b/CE02SHSM/CE02SHSM_R00017_ingest.csv
@@ -1,0 +1,33 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/cpm2/syslog/cpm_status.txt,CE02SHSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl26/syslog/*.syslog.log,CE02SHSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl26/adcpt/*.adcpt.log,CE02SHSM-RID26-01-ADCPTA000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/instrmts/dcl26/ADCPT*/*adcpt*.000,CE02SHSM-RID26-01-ADCPTA000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl26/velpt*/*.velpt*.log,CE02SHSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/instrmts/dcl26/VELPT*/*velpt*.aqd,CE02SHSM-RID26-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl26/phsen/*.phsen.log,CE02SHSM-RID26-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE02SHSM-RID26-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl26/nutnr/*.nutnr.log,CE02SHSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE02SHSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl26/spkir/*.spkir.log,CE02SHSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl27/syslog/*.syslog.log,CE02SHSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl27/optaa/*.optaa.log,CE02SHSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl27/flort/*.flort.log,CE02SHSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl27/ctdbp/*.ctdbp.log,CE02SHSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/instrmts/dcl27/CTDBP*/*ctdbp*.hex,CE02SHSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl27/dosta/*.dosta.log,CE02SHSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/irid2shore/cpm_status*.txt,CE02SHSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl11/syslog/*.syslog.log,CE02SHSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl11/mopak/*.mopak.log,CE02SHSM-SBD11-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl11/hyd*/*.hyd*.log,CE02SHSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl11/velpt*/*.velpt*.log,CE02SHSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/instrmts/dcl11/VELPT*/*velpt*.aqd,CE02SHSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl11/metbk/*.metbk.log,CE02SHSM-SBD11-06-METBKA000,recovered_host,Available,
+mi.dataset.driver.metbk_ct.dcl.metbk_ct_dcl_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl11/metbk/*.metbk.log,CE02SHSM-SBD11-06-METBKA001,recovered_host,Available,
+mi.dataset.driver.metbk_ct.metbk_ct_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/instrmts/dcl11/METBK-CT*/*.hex,CE02SHSM-SBD11-06-METBKA001,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl12/syslog/*.syslog.log,CE02SHSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl12/hyd*/*.hyd*.log,CE02SHSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl12/pco2a/*.pco2a.log,CE02SHSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl12/wavss/*.wavss.log,CE02SHSM-SBD12-05-WAVSSA000,recovered_host,Available,
+mi.dataset.driver.fdchp_a.dcl.fdchp_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/cg_data/dcl12/fdchp/*.fdchp.log,CE02SHSM-SBD12-08-FDCHPA000,recovered_host,Available,
+mi.dataset.driver.fdchp_a.fdchp_a_recovered_driver,/omc_data/whoi/OMC/CE02SHSM/R00017/instrmts/dcl12/FDCHP*/*fdchp*/*/fdchp*.dat,CE02SHSM-SBD12-08-FDCHPA000,recovered_inst,Available,

--- a/CE04OSSM/CE04OSSM_R00016_ingest.csv
+++ b/CE04OSSM/CE04OSSM_R00016_ingest.csv
@@ -1,0 +1,31 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/cpm2/syslog/cpm_status.txt,CE04OSSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl26/syslog/*.syslog.log,CE04OSSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl26/adcpt/*.adcpt.log,CE04OSSM-RID26-01-ADCPTC000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/instrmts/dcl26/ADCPT*/*adcpt*.000,CE04OSSM-RID26-01-ADCPTC000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl26/velpt*/*.velpt*.log,CE04OSSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/instrmts/dcl26/VELPT*/*velpt*.aqd,CE04OSSM-RID26-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl26/phsen/*.phsen.log,CE04OSSM-RID26-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE04OSSM-RID26-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl26/nutnr/*.nutnr.log,CE04OSSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE04OSSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl26/spkir/*.spkir.log,CE04OSSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl27/syslog/*.syslog.log,CE04OSSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl27/optaa/*.optaa.log,CE04OSSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl27/flort/*.flort.log,CE04OSSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl27/ctdbp/*.ctdbp.log,CE04OSSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/instrmts/dcl27/CTDBP*/*ctdbp*.hex,CE04OSSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl27/dosta/*.dosta.log,CE04OSSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/irid2shore/cpm_status*.txt,CE04OSSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl11/syslog/*.syslog.log,CE04OSSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl11/mopak/*.mopak.log,CE04OSSM-SBD11-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl11/hyd*/*.hyd*.log,CE04OSSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl11/velpt*/*.velpt*.log,CE04OSSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/instrmts/dcl11/VELPT*/*velpt*.aqd,CE04OSSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA000,recovered_host,Available,
+mi.dataset.driver.metbk_ct.dcl.metbk_ct_dcl_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl11/metbk/*.metbk.log,CE04OSSM-SBD11-06-METBKA001,recovered_host,Available,
+mi.dataset.driver.metbk_ct.metbk_ct_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/instrmts/dcl11/METBK-CT*/*.hex,CE04OSSM-SBD11-06-METBKA001,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl12/syslog/*.syslog.log,CE04OSSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl12/hyd*/*.hyd*.log,CE04OSSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl12/pco2a/*.pco2a.log,CE04OSSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE04OSSM/R00016/cg_data/dcl12/wavss/*.wavss.log,CE04OSSM-SBD12-05-WAVSSA000,recovered_host,Available,

--- a/CE06ISSM/CE06ISSM_R00018_ingest.csv
+++ b/CE06ISSM/CE06ISSM_R00018_ingest.csv
@@ -1,0 +1,53 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/cpm3/syslog*/cpm_status.txt,CE06ISSM-MFC31-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl36/syslog*/*syslog*.log,CE06ISSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl36/vel3d*/*vel3d*.log,CE06ISSM-MFD35-01-VEL3DD000,recovered_host,Available,
+# ,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/VEL3D*/*vel3d*.VEC,CE06ISSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this dataset
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl36/presf*/*presf*.log,CE06ISSM-MFD35-02-PRESFA000,recovered_host,Available,
+mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/PRESF*/*presf*.hex,CE06ISSM-MFD35-02-PRESFA000,recovered_inst,Available,
+mi.dataset.driver.presf_abc.presf_abc_wave_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/PRESF*/*presf*.hex,CE06ISSM-MFD35-02-PRESFA000,recovered_inst,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl36/adcpt*/*adcpt*.log,CE06ISSM-MFD35-04-ADCPTM000,recovered_host,Available,
+# mi.dataset.driver.adcpt_m.adcpt_m_dspec_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/ADCPT*/*adcpt*/DSpec*.txt,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Pending,Updated processing application with reviews required
+# mi.dataset.driver.adcpt_m.adcpt_m_fcoeff_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/ADCPT*/*adcpt*/Coeffs*.txt,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Pending,Updated processing application with reviews required
+# mi.dataset.driver.adcpt_m.adcpt_m_log9_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/ADCPT*/*adcpt*/*LogData.000,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Pending,Updated processing application with reviews required
+# mi.dataset.driver.adcpt_m.wvs.adcpt_m_wvs_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/ADCPT*/*adcpt*/*.WVS,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Pending,Updated processing application with reviews required
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/ADCPT*/*adcpt*/*CurrentsData.000,CE06ISSM-MFD35-04-ADCPTM000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl36/pco2w*/*pco2w*.log,CE06ISSM-MFD35-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE06ISSM-MFD35-05-PCO2WB000,recovered_inst,Available,
+# mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl36/phsen*/*phsen*.log,CE06ISSM-MFD35-06-PHSEND000,recovered_host,Not Deployed,Instrument not returned from vendor in time for deployment
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE06ISSM-MFD35-06-PHSEND000,recovered_inst,Not Deployed,Instrument not returned from vendor in time for deployment
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl37/syslog*/*syslog*.log,CE06ISSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl37/optaa*/*optaa*.log,CE06ISSM-MFD37-01-OPTAAD000,recovered_host,Not Deployed,Instrument not returned from vendor in time for deployment
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE06ISSM-MFD37-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE06ISSM-MFD37-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl37/ctdbp*/*ctdbp*.log,CE06ISSM-MFD37-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE06ISSM-MFD37-03-DOSTAD000,recovered_inst,Available,
+# ,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl37/camds/*.png,CE06ISSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
+# ,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl37/CAMDS*/*camds*/DCIM/*.png,CE06ISSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl37/zplsc/*zplsc.log,CE06ISSM-MFD37-07-ZPLSCC000,recovered_host,Available,
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE06ISSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/syslog*/*syslog*.log,CE06ISSM-RID16-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/optaa*/*optaa*.log,CE06ISSM-RID16-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/flort*/*flort*.log,CE06ISSM-RID16-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE06ISSM-RID16-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE06ISSM-RID16-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/ctdbp*/*ctdbp*.log,CE06ISSM-RID16-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl16/CTDBP*/*ctdbp*.hex,CE06ISSM-RID16-03-DOSTAD000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/velpt*/*velpt*.log,CE06ISSM-RID16-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl16/VELPT*/*velpt*.aqd,CE06ISSM-RID16-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/pco2w*/*pco2w*.log,CE06ISSM-RID16-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl16/PCO2W*/*pco2w*recovered*.txt,CE06ISSM-RID16-05-PCO2WB000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/phsen*/*phsen*.log,CE06ISSM-RID16-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl16/PHSEN*/*phsen*recovered*.txt,CE06ISSM-RID16-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/nutnr*/*nutnr*.log,CE06ISSM-RID16-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl16/NUTNR*/*nutnr*/D*.CSV,CE06ISSM-RID16-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl16/spkir*/*spkir*.log,CE06ISSM-RID16-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/irid2shore/cpm_status*.txt,CE06ISSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl17/syslog*/*syslog*.log,CE06ISSM-SBD17-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl17/mopak*/*mopak*.log,CE06ISSM-SBD17-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl17/velpt*/*velpt*.log,CE06ISSM-SBD17-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl17/VELPT*/*velpt*.aqd,CE06ISSM-SBD17-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl17/ctdbp*/*ctdbp3.log,CE06ISSM-SBD17-06-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl17/CTDBP*/*ctdbp*.hex,CE06ISSM-SBD17-06-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/cg_data/dcl17/ctdbp*/*ctdbp3.log,CE06ISSM-SBD17-06-FLORTD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.flort_dj_recovered_driver,/omc_data/whoi/OMC/CE06ISSM/R00018/instrmts/dcl17/CTDBP*/*ctdbp*.hex,CE06ISSM-SBD17-06-FLORTD000,recovered_inst,Available,

--- a/CE07SHSM/CE07SHSM_R00017_ingest.csv
+++ b/CE07SHSM/CE07SHSM_R00017_ingest.csv
@@ -1,0 +1,54 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/cpm3/syslog/cpm_status.txt,CE07SHSM-MFC31-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl36/syslog/*.syslog.log,CE07SHSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl36/vel3d/*.vel3d.log,CE07SHSM-MFD35-01-VEL3DD000,recovered_host,Available,
+# ,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl36/VEL3D*/*vel3d*.VEC,CE07SHSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this dataset
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl36/presf/*.presf.log,CE07SHSM-MFD35-02-PRESFB000,recovered_host,Available,
+mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl36/PRESF*/*presf*.hex,CE07SHSM-MFD35-02-PRESFB000,recovered_inst,Available,
+mi.dataset.driver.presf_abc.presf_abc_wave_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl36/PRESF*/*presf*.hex,CE07SHSM-MFD35-02-PRESFB000,recovered_inst,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl36/adcpt2/*.adcpt*.log,CE07SHSM-MFD35-04-ADCPTC000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl36/ADCPT*/*.000,CE07SHSM-MFD35-04-ADCPTC000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl36/pco2w/*.pco2w.log,CE07SHSM-MFD35-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE07SHSM-MFD35-05-PCO2WB000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl36/phsen2/*.phsen*.log,CE07SHSM-MFD35-06-PHSEND000,recovered_host,Not Deployed,Instrument not returned from vendor in time for deployment
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE07SHSM-MFD35-06-PHSEND000,recovered_inst,Not Deployed,Instrument not returned from vendor in time for deployment
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl37/syslog/*.syslog.log,CE07SHSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl37/optaa2/*.optaa*.log,CE07SHSM-MFD37-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl37/ctdbp2/*.ctdbp*.log,CE07SHSM-MFD37-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE07SHSM-MFD37-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl37/ctdbp2/*.ctdbp*.log,CE07SHSM-MFD37-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE07SHSM-MFD37-03-DOSTAD000,recovered_inst,Available,
+# ,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl37/camds/*.png,CE07SHSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
+# ,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl37/CAMDS_*/*camds*/DCIM/*.png,CE07SHSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl37/zplsc/*.zplsc.log,CE07SHSM-MFD37-07-ZPLSCC000,recovered_host,Available,
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE07SHSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/cpm2/syslog/cpm_status.txt,CE07SHSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl26/syslog/*.syslog.log,CE07SHSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl26/adcpt1/*.adcpt*.log,CE07SHSM-RID26-01-ADCPTA000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl26/ADCPT*/*adcpt*.000,CE07SHSM-RID26-01-ADCPTA000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl26/velpt2/*.velpt*.log,CE07SHSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl26/VELPT*/*velpt*.aqd,CE07SHSM-RID26-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl26/phsen*/*.phsen*.log,CE07SHSM-RID26-06-PHSEND000,recovered_host,Available,
+mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE07SHSM-RID26-06-PHSEND000,recovered_inst,Available,
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl26/nutnr/*.nutnr.log,CE07SHSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE07SHSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl26/spkir/*.spkir.log,CE07SHSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl27/syslog/*.syslog.log,CE07SHSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl27/optaa1/*.optaa*.log,CE07SHSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl27/flort/*.flort.log,CE07SHSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl27/ctdbp1/*.ctdbp*.log,CE07SHSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl27/CTDBP*/*ctdbp*.hex,CE07SHSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl27/dosta/*.dosta.log,CE07SHSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/irid2shore/cpm_status*.txt,CE07SHSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl11/syslog/*.syslog.log,CE07SHSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl11/mopak/*.mopak.log,CE07SHSM-SBD11-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl11/hyd1/*.hyd1.log,CE07SHSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl11/velpt1/*.velpt1.log,CE07SHSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl11/VELPT*/*velpt*.aqd,CE07SHSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl11/metbk/*.metbk.log,CE07SHSM-SBD11-06-METBKA000,recovered_host,Available,
+mi.dataset.driver.metbk_ct.dcl.metbk_ct_dcl_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl11/metbk/*.metbk.log,CE07SHSM-SBD11-06-METBKA001,recovered_host,Available,
+mi.dataset.driver.metbk_ct.metbk_ct_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/instrmts/dcl11/METBK-CT*/*.hex,CE07SHSM-SBD11-06-METBKA001,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl12/syslog/*.syslog.log,CE07SHSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl12/hyd2/*.hyd2.log,CE07SHSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl12/pco2a/*.pco2a.log,CE07SHSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE07SHSM/R00017/cg_data/dcl12/wavss/*.wavss.log,CE07SHSM-SBD12-05-WAVSSA000,recovered_host,Available,

--- a/CE09OSPM/CE09OSPM_D00001_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00001_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
-mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00001/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00001/irid2shore/stc_status.*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00001/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00001/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00001/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00001/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00002_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00002_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00002/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00002/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00002/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00002/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00002/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00003_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00003_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00003/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00003/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00003/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00003/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00003/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00004_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00004_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00004/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00004/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00004/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00004/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00004/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00005_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00005_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00005/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00005/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00005/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00005/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00005/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00006_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00006_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00006/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00006/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00006/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00006/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00006/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00007_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00007_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00007/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00007/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00007/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00007/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00007/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00008_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00008_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00008/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00008/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00008/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00008/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00008/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00009_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00009_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00009/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00009/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00009/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00009/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00009/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00010_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00010_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00010/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00010/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00010/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00010/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00010/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00011_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00011_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00011/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00011/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00011/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00011/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00011/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00012_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00012_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00012/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00012/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00012/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00012/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00012/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00013_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00013_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00013/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00013/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00013/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00013/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00013/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00014_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00014_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00014/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00011/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00014/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00014/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00014/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00015_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00015_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00015/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00015/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00015/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00015/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00015/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00016_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00016_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00016/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00016/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00016/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00016/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00016/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00017_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00017_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00017/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00017/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00017/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00017/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00017/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00018_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00018_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00018/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00018/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00018/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00018/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00018/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00019_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00019_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00019/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00019/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00019/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00019/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00019/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_D00020_ingest.csv
+++ b/CE09OSPM/CE09OSPM_D00020_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00020/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,telemetered,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00020/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,telemetered,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00020/imm/mmp/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,telemetered,Available,
 mi.dataset.driver.vel3d_k.wfp_stc.vel3d_k_wfp_stc_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00020/imm/mmp/A*.DEC,CE09OSPM-WFP01-01-VEL3DK000,telemetered,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_telemetered_driver,/omc_data/whoi/OMC/CE09OSPM/D00020/imm/mmp/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,telemetered,Available,

--- a/CE09OSPM/CE09OSPM_R00001_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00001_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00001/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00001/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00001/instrmts/CWFP*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00001/instrmts/CWFP*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00001/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00002_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00002_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00002/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00002/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00002/instrmts/CWFP*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00002/instrmts/CWFP*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00002/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00003_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00003_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00003/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00003/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00003/instrmts/CWFP*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00003/instrmts/CWFP*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00003/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00004_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00004_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00004/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00004/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00004/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00004/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00004/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00005_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00005_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00005/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00005/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00005/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00005/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00005/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00006_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00006_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 # mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00006/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Not Expected,Profiler lost at sea
+# mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00006/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 # mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00006/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Not Expected,Profiler lost at sea
 # mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00006/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Not Expected,Profiler lost at sea
 # mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00006/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Not Expected,Profiler lost at sea

--- a/CE09OSPM/CE09OSPM_R00007_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00007_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00007/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00007/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00007/instrmts/CWFP*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00007/instrmts/CWFP*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00007/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00008_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00008_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00008/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00008/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00008/instrmts/CWFP*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00008/instrmts/CWFP*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00008/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00009_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00009_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00009/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00009/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00009/instrmts/CWFP*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00009/instrmts/CWFP*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00009/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00010_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00010_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00010/instrmts/CWFP*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00010/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.ctdpf_ckl.wfp.coastal_ctdpf_ckl_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00010/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-03-CTDPFK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00010/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00010/instrmts/CWFP*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00011_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00011_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00011/instrmts/CWFP*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00011/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.ctdpf_ckl.wfp.coastal_ctdpf_ckl_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00011/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-03-CTDPFK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00011/instrmts/CWFP*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00011/instrmts/CWFP*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00012_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00012_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00012/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00012/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00012/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00012/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00012/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00013_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00013_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00013/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00013/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00013/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00013/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00013/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00014_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00014_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00014/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00015_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00015_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00015/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00015/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00015/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00015/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00015/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00016_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00016_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00016/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00016/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00016/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00016/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00016/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00017_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00017_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00017/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00017/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00017/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00017/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00017/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00018_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00018_ingest.csv
@@ -1,5 +1,6 @@
 parser,filename_mask,reference_designator,data_source,status,notes
 mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00018/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00018/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
 mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00018/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
 mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00018/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
 mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00018/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,

--- a/CE09OSPM/CE09OSPM_R00019_ingest.csv
+++ b/CE09OSPM/CE09OSPM_R00019_ingest.csv
@@ -1,0 +1,9 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+mi.dataset.driver.cg_stc_eng.stc.cg_stc_eng_stc_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00019/cg_data/irid2shore/stc_status.*_*.txt,CE09OSPM-SBS01-00-STCENG000,recovered_host,Available,
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00019/cg_data/stc1/3dmgx3/*.3dmgx3.log,CE09OSPM-SBS01-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.WFP_ENG.STC_IMODEM.wfp_eng_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00019/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-00-WFPENG000,recovered_wfp,Available,
+mi.dataset.driver.vel3d_k.wfp.vel3d_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00019/instrmts/CWFP*/*/A*.DAT,CE09OSPM-WFP01-01-VEL3DK000,recovered_wfp,Available,
+mi.dataset.driver.dofst_k.wfp.coastal_dofst_k_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00019/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-02-DOFSTK000,recovered_wfp,Available,
+mi.dataset.driver.ctdpf_ckl.wfp.coastal_ctdpf_ckl_wfp_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00019/instrmts/CWFP*/*/C*.DAT,CE09OSPM-WFP01-03-CTDPFK000,recovered_wfp,Available,
+mi.dataset.driver.flort_kn.stc_imodem.flort_kn__stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00019/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-04-FLORTK000,recovered_wfp,Available,
+mi.dataset.driver.PARAD_K.STC_IMODEM.parad_k_stc_imodem_recovered_driver,/omc_data/whoi/OMC/CE09OSPM/R00019/instrmts/CWFP*/*/E*.DAT,CE09OSPM-WFP01-05-PARADK000,recovered_wfp,Available,

--- a/CE09OSSM/CE09OSSM_R00017_ingest.csv
+++ b/CE09OSSM/CE09OSSM_R00017_ingest.csv
@@ -1,0 +1,53 @@
+parser,filename_mask,reference_designator,data_source,status,notes
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/cpm3/syslog/cpm_status.txt,CE09OSSM-MFC31-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl36/syslog/*.syslog.log,CE09OSSM-MFD35-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.vel3d_cd.dcl.vel3d_cd_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl36/vel3d/*.vel3d.log,CE09OSSM-MFD35-01-VEL3DD000,recovered_host,Available,
+# ,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl36/VEL3D_*/*.VEC,CE09OSSM-MFD35-01-VEL3DD000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.presf_abc.dcl.presf_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl36/presf/*.presf.log,CE09OSSM-MFD35-02-PRESFC000,recovered_host,Available,
+mi.dataset.driver.presf_abc.presf_abc_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl36/PRESF*/*presf*.hex,CE09OSSM-MFD35-02-PRESFC000,recovered_inst,Available,
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl36/adcps/*.adcps.log,CE09OSSM-MFD35-04-ADCPSJ000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl36/ADCPS*/*.000,CE09OSSM-MFD35-04-ADCPSJ000,recovered_inst,Available,
+mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl36/pco2w/*.pco2w.log,CE09OSSM-MFD35-05-PCO2WB000,recovered_host,Available,
+mi.dataset.driver.pco2w_abc.pco2w_abc_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl36/PCO2W*/*pco2w*recovered*.txt,CE09OSSM-MFD35-05-PCO2WB000,recovered_inst,Available,
+# mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl36/phsen2/*.phsen2.log,CE09OSSM-MFD35-06-PHSEND000,recovered_host,Not Deployed,Instrument not returned from vendor in time for deployment
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl36/PHSEN*/*phsen*recovered*.txt,CE09OSSM-MFD35-06-PHSEND000,recovered_inst,Not Deployed,Instrument not returned from vendor in time for deployment
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl37/syslog/*.syslog.log,CE09OSSM-MFD37-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl37/optaa2/*.optaa2.log,CE09OSSM-MFD37-01-OPTAAC000,recovered_host,Not Deployed,Instrument not returned from vendor in time for deployment
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl37/ctdbp2/*.ctdbp2.log,CE09OSSM-MFD37-03-CTDBPE000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE09OSSM-MFD37-03-CTDBPE000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl37/ctdbp2/*.ctdbp2.log,CE09OSSM-MFD37-03-DOSTAD000,recovered_host,Available,
+mi.dataset.driver.dosta_abcdjm.ctdbp.dosta_abcdjm_ctdbp_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl37/CTDBP*/*ctdbp*.hex,CE09OSSM-MFD37-03-DOSTAD000,recovered_inst,Available,
+# ,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl37/camds/*.png,CE09OSSM-MFD37-06-CAMDSA000,recovered_host,Pending,No parser exists for this data set
+# ,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl37/CAMDS_*/*camds*/dcim/*.png,CE09OSSM-MFD37-06-CAMDSA000,recovered_inst,Pending,No parser exists for this data set
+mi.dataset.driver.zplsc_c.dcl.zplsc_c_dcl_telemetered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl37/zplsc/*.zplsc.log,CE09OSSM-MFD37-07-ZPLSCC000,recovered_host,Available,
+mi.dataset.driver.zplsc_c.zplsc_echogram_uploader,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl37/ZPLSC*/processed/*/*Averaged.nc,CE09OSSM-MFD37-07-ZPLSCC000,recovered_inst,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/cpm2/syslog/cpm_status.txt,CE09OSSM-RIC21-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl26/syslog/*.syslog.log,CE09OSSM-RID26-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.adcpt_acfgm.dcl.pd0.adcpt_acfgm_dcl_pd0_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl26/adcpt*/*.adcpt.log,CE09OSSM-RID26-01-ADCPTC000,recovered_host,Available,
+mi.dataset.driver.adcps_jln.adcps_jln_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl26/ADCPT*/*adcpt*.000,CE09OSSM-RID26-01-ADCPTC000,recovered_inst,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl26/velpt2/*.velpt2.log,CE09OSSM-RID26-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl26/VELPT*/*velpt*.aqd,CE09OSSM-RID26-04-VELPTA000,recovered_inst,Available,
+# mi.dataset.driver.phsen_abcdef.dcl.phsen_abcdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl26/phsen*/*.phsen*.log,CE09OSSM-RID26-06-PHSEND000,recovered_host,Not Deployed,Instrument not returned from vendor in time for deployment
+# mi.dataset.driver.phsen_abcdef.phsen_abcdef_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl26/PHSEN*/*phsen*recovered*.txt,CE09OSSM-RID26-06-PHSEND000,recovered_inst,Not Deployed,Instrument not returned from vendor in time for deployment
+mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl26/nutnr*/*.nutnr.log,CE09OSSM-RID26-07-NUTNRB000,recovered_host,Available,
+mi.dataset.driver.suna.suna_instrument_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl26/NUTNR*/*nutnr*/D*.CSV,CE09OSSM-RID26-07-NUTNRB000,recovered_inst,Available,
+mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl26/spkir*/*.spkir.log,CE09OSSM-RID26-08-SPKIRB000,recovered_host,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl27/syslog/*.syslog.log,CE09OSSM-RID27-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.optaa_dj.dcl.optaa_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl27/optaa1/*.optaa1.log,CE09OSSM-RID27-01-OPTAAD000,recovered_host,Available,
+mi.dataset.driver.flort_dj.dcl.flort_dj_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl27/flort/*.flort.log,CE09OSSM-RID27-02-FLORTD000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.dcl.ctdbp_cdef_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl27/ctdbp1/*.ctdbp1.log,CE09OSSM-RID27-03-CTDBPC000,recovered_host,Available,
+mi.dataset.driver.ctdbp_cdef.ctdbp_cdef_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl27/CTDBP*/*.hex,CE09OSSM-RID27-03-CTDBPC000,recovered_inst,Available,
+mi.dataset.driver.dosta_abcdjm.dcl.dosta_abcdjm_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl27/dosta/*.dosta.log,CE09OSSM-RID27-04-DOSTAD000,recovered_host,Available,
+# mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/irid2shore/cpm_status.*.txt,CE09OSSM-SBC11-00-CPMENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl11/syslog/*.syslog.log,CE09OSSM-SBD11-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.cg_stc_eng.stc.mopak_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl11/mopak/*.mopak.log,CE09OSSM-SBD11-01-MOPAK0000,recovered_host,Available,
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl11/hyd1/*.log,CE09OSSM-SBD11-02-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl11/velpt1/*.velpt1.log,CE09OSSM-SBD11-04-VELPTA000,recovered_host,Available,
+mi.dataset.driver.velpt_ab.velpt_ab_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl11/VELPT*/*velpt*.aqd,CE09OSSM-SBD11-04-VELPTA000,recovered_inst,Available,
+mi.dataset.driver.metbk_a.dcl.metbk_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl11/metbk/*.metbk.log,CE09OSSM-SBD11-06-METBKA000,recovered_host,Available,
+mi.dataset.driver.metbk_ct.dcl.metbk_ct_dcl_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl11/metbk/*.metbk.log,CE09OSSM-SBD11-06-METBKA001,recovered_host,Available,
+mi.dataset.driver.metbk_ct.metbk_ct_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/instrmts/dcl11/METBK-CT*/*.hex,CE09OSSM-SBD11-06-METBKA001,recovered_inst,Available,
+# mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl12/syslog/*.syslog.log,CE09OSSM-SBD12-00-DCLENG000,recovered_host,Pending,Incorrectly specified dataset and parser
+mi.dataset.driver.hyd_o.dcl.hyd_o_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl12/hyd2/*.log,CE09OSSM-SBD12-03-HYDGN0000,recovered_host,Available,
+mi.dataset.driver.pco2a_a.sample.pco2a_a_sample_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl12/pco2a/*.pco2a.log,CE09OSSM-SBD12-04-PCO2AA000,recovered_host,Available,
+mi.dataset.driver.wavss_a.dcl.wavss_a_dcl_recovered_driver,/omc_data/whoi/OMC/CE09OSSM/R00017/cg_data/dcl12/wavss/*.wavss.log,CE09OSSM-SBD12-05-WAVSSA000,recovered_host,Available,


### PR DESCRIPTION
Adds ingest CSVs for the Endurance 19 recovered moorings and updates the Washington offshore profiler mooring ingests to include the MOPAK data.