### PR TITLE
DCL port failed prior to deployment

### DIFF
--- a/CE06ISSM/CE06ISSM_D00020_ingest.csv
+++ b/CE06ISSM/CE06ISSM_D00020_ingest.csv
@@ -20,7 +20,7 @@ mi.dataset.driver.dosta_abcdjm.ctdbp.dcl.dosta_abcdjm_ctdbp_dcl_telemetered_driv
 mi.dataset.driver.velpt_ab.dcl.velpt_ab_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00020/cg_data/dcl16/velpt2/*.velpt*.log,CE06ISSM-RID16-04-VELPTA000,telemetered,Available,
 mi.dataset.driver.pco2w_abc.dcl.pco2w_abc_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00020/cg_data/dcl16/pco2w1/*.pco2w*.log,CE06ISSM-RID16-05-PCO2WB000,telemetered,Available,
 # ,/omc_data/whoi/OMC/CE06ISSM/D00020/cg_data/dcl16/phsen1/*.phsen*.log,CE06ISSM-RID16-06-PHSEND000,telemetered,Pending,New parser required for the SeapHOx
-mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE06ISSM/D00020/cg_data/dcl16/nutnr/*.nutnr.log,CE06ISSM-RID16-07-NUTNRB000,telemetered,Available,
+# mi.dataset.driver.suna.suna_dcl_driver,/omc_data/whoi/OMC/CE06ISSM/D00020/cg_data/dcl16/nutnr/*.nutnr.log,CE06ISSM-RID16-07-NUTNRB000,telemetered,Not Expected,Instrument removed due to logger port failure,
 mi.dataset.driver.spkir_abj.dcl.spkir_abj_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00020/cg_data/dcl16/spkir/*.spkir.log,CE06ISSM-RID16-08-SPKIRB000,telemetered,Available,
 # mi.dataset.driver.cg_cpm_eng.cpm.cg_cpm_eng_cpm_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00020/irid2shore/cpm_status*.txt,CE06ISSM-SBC11-00-CPMENG000,telemetered,Pending,Incorrectly specified dataset and parser
 # mi.dataset.driver.cg_dcl_eng.dcl.cg_dcl_eng_dcl_telemetered_driver,/omc_data/whoi/OMC/CE06ISSM/D00020/cg_data/dcl17/syslog/*.syslog.log,CE06ISSM-SBD17-00-DCLENG000,telemetered,Pending,Incorrectly specified driver and dataset


### PR DESCRIPTION
Quick update to capture the failed DCL port on CE06ISSM (no NUTNR data for this deployment)